### PR TITLE
SAM to RAM conversion time benchmark

### DIFF
--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -20,14 +20,22 @@ ROOT_EXECUTABLE(sam_to_ram_benchmark
         sam_generator
 )
 
-install(TARGETS sam_to_ram_benchmark
+ROOT_EXECUTABLE(conversion_time_benchmark
+    conversion_time_benchmark.cxx
+    LIBRARIES
+        benchmark::benchmark
+        ramcore
+        sam_generator
+)
+
+install(TARGETS sam_to_ram_benchmark conversion_time_benchmark
     RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
 )
 
 add_custom_target(benchmark
     COMMAND sam_to_ram_benchmark
-    DEPENDS sam_to_ram_benchmark
+    COMMAND conversion_time_benchmark
+    DEPENDS sam_to_ram_benchmark conversion_time_benchmark
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-    COMMENT "Running SAM to RAM conversion benchmark"
 )
 

--- a/benchmark/conversion_time_benchmark.cxx
+++ b/benchmark/conversion_time_benchmark.cxx
@@ -7,9 +7,9 @@
 #include <cstdio>
 
 #ifdef _WIN32
-    #define NULL_DEVICE "NUL"
+#define NULL_DEVICE "NUL"
 #else
-    #define NULL_DEVICE "/dev/null"
+#define NULL_DEVICE "/dev/null"
 #endif
 
 static void BM_SamToTTree(benchmark::State &state)
@@ -95,4 +95,3 @@ int main(int argc, char **argv)
    ::benchmark::RunSpecifiedBenchmarks();
    return 0;
 }
-

--- a/benchmark/conversion_time_benchmark.cxx
+++ b/benchmark/conversion_time_benchmark.cxx
@@ -1,0 +1,91 @@
+#include <benchmark/benchmark.h>
+#include "generate_sam_benchmark.h"
+#include "ramcore/SamToTTree.h"
+#include "ramcore/SamToNTuple.h"
+#include <filesystem>
+#include <iostream>
+#include <cstdio>
+
+static void BM_SamToTTree(benchmark::State &state)
+{
+   int num_reads = state.range(0);
+   std::string sam_file = "ttree_test.sam";
+   std::string ttree_file = "ttree_output.root";
+
+   GenerateSAMFile(sam_file, num_reads);
+
+   for (auto _ : state) {
+
+      FILE *original_stdout = stdout;
+      stdout = fopen("/dev/null", "w");
+
+      samtoram(sam_file.c_str(), ttree_file.c_str(), true, true, true, 1, 0);
+
+      fclose(stdout);
+      stdout = original_stdout;
+
+      if (std::filesystem::exists(ttree_file)) {
+         auto file_size = std::filesystem::file_size(ttree_file);
+         state.counters["file_size_mb"] = file_size / (1024.0 * 1024.0);
+      }
+
+      std::remove(ttree_file.c_str());
+   }
+
+   std::remove(sam_file.c_str());
+   state.counters["reads_per_second"] = benchmark::Counter(num_reads, benchmark::Counter::kIsRate);
+}
+
+static void BM_SamToRNTuple(benchmark::State &state)
+{
+   int num_reads = state.range(0);
+   std::string sam_file = "rntuple_test.sam";
+   std::string rntuple_file = "rntuple_output.root";
+
+   GenerateSAMFile(sam_file, num_reads);
+
+   for (auto _ : state) {
+
+      FILE *original_stdout = stdout;
+      stdout = fopen("/dev/null", "w");
+
+      samtoramntuple(sam_file.c_str(), rntuple_file.c_str(), true, true, true, 505, 0);
+
+      fclose(stdout);
+      stdout = original_stdout;
+
+      if (std::filesystem::exists(rntuple_file)) {
+         auto file_size = std::filesystem::file_size(rntuple_file);
+         state.counters["file_size_mb"] = file_size / (1024.0 * 1024.0);
+      }
+
+      std::remove(rntuple_file.c_str());
+   }
+
+   std::remove(sam_file.c_str());
+   state.counters["reads_per_second"] = benchmark::Counter(num_reads, benchmark::Counter::kIsRate);
+}
+
+int main(int argc, char **argv)
+{
+   std::cout << "Individual Conversion Time Benchmark" << std::endl;
+   std::cout << "====================================" << std::endl;
+   std::cout << "Measuring TTree and RNTuple conversion times separately" << std::endl;
+   std::cout << std::endl;
+
+   ::benchmark::RegisterBenchmark("TTree_Conversion", BM_SamToTTree)
+      ->Args({1000})
+      ->Args({10000})
+      ->Args({100000})
+      ->Unit(benchmark::kMillisecond);
+
+   ::benchmark::RegisterBenchmark("RNTuple_Conversion", BM_SamToRNTuple)
+      ->Args({1000})
+      ->Args({10000})
+      ->Args({100000})
+      ->Unit(benchmark::kMillisecond);
+
+   ::benchmark::Initialize(&argc, argv);
+   ::benchmark::RunSpecifiedBenchmarks();
+   return 0;
+}

--- a/benchmark/conversion_time_benchmark.cxx
+++ b/benchmark/conversion_time_benchmark.cxx
@@ -6,6 +6,12 @@
 #include <iostream>
 #include <cstdio>
 
+#ifdef _WIN32
+    #define NULL_DEVICE "NUL"
+#else
+    #define NULL_DEVICE "/dev/null"
+#endif
+
 static void BM_SamToTTree(benchmark::State &state)
 {
    int num_reads = state.range(0);
@@ -17,7 +23,7 @@ static void BM_SamToTTree(benchmark::State &state)
    for (auto _ : state) {
 
       FILE *original_stdout = stdout;
-      stdout = fopen("/dev/null", "w");
+      stdout = fopen(NULL_DEVICE, "w");
 
       samtoram(sam_file.c_str(), ttree_file.c_str(), true, true, true, 1, 0);
 
@@ -47,7 +53,7 @@ static void BM_SamToRNTuple(benchmark::State &state)
    for (auto _ : state) {
 
       FILE *original_stdout = stdout;
-      stdout = fopen("/dev/null", "w");
+      stdout = fopen(NULL_DEVICE, "w");
 
       samtoramntuple(sam_file.c_str(), rntuple_file.c_str(), true, true, true, 505, 0);
 
@@ -89,3 +95,4 @@ int main(int argc, char **argv)
    ::benchmark::RunSpecifiedBenchmarks();
    return 0;
 }
+

--- a/benchmark/sam_to_ram_benchmark.cxx
+++ b/benchmark/sam_to_ram_benchmark.cxx
@@ -7,6 +7,12 @@
 #include <cstdio>
 #include <cstring>
 
+#ifdef _WIN32
+    #define NULL_DEVICE "NUL"
+#else
+    #define NULL_DEVICE "/dev/null"
+#endif
+
 static void BM_SamToRamComparison(benchmark::State &state)
 {
    int num_reads = state.range(0);
@@ -20,7 +26,7 @@ static void BM_SamToRamComparison(benchmark::State &state)
    for (auto _ : state) {
 
       FILE *original_stdout = stdout;
-      stdout = fopen("/dev/null", "w");
+      stdout = fopen(NULL_DEVICE, "w");
 
       samtoram(sam_file.c_str(), ttree_file.c_str(), true, true, true, 1, 0);
 
@@ -68,3 +74,4 @@ int main(int argc, char **argv)
    ::benchmark::RunSpecifiedBenchmarks();
    return 0;
 }
+

--- a/benchmark/sam_to_ram_benchmark.cxx
+++ b/benchmark/sam_to_ram_benchmark.cxx
@@ -8,9 +8,9 @@
 #include <cstring>
 
 #ifdef _WIN32
-    #define NULL_DEVICE "NUL"
+#define NULL_DEVICE "NUL"
 #else
-    #define NULL_DEVICE "/dev/null"
+#define NULL_DEVICE "/dev/null"
 #endif
 
 static void BM_SamToRamComparison(benchmark::State &state)
@@ -74,4 +74,3 @@ int main(int argc, char **argv)
    ::benchmark::RunSpecifiedBenchmarks();
    return 0;
 }
-


### PR DESCRIPTION
This PR modifies to benchmark the conversion time from SAM to RAM in both the formats ttree and RNTuple formats.