### PR TITLE
ramntupleview refactor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,10 +3,11 @@ ramexample.root
 *.log
 *.perf
 *.bam
+*.sam
+*.png
 *.bam.bai
 *.root
 *.root.idx
-*.png
 .ipynb_checkpoints/
 tmp/
 *.so

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,12 +29,14 @@ set(CMAKE_INSTALL_INCLUDEDIR include)
         inc/ramcore/SamParser.h
         inc/ramcore/SamToTTree.h
         inc/ramcore/SamToNTuple.h
+        inc/ramcore/RAMNTupleView.h
     SOURCES
         src/ttree/RAMRecord.cxx
         src/rntuple/RAMNTupleRecord.cxx
         src/ramcore/SamParser.cxx
         src/ramcore/SamToTTree.cxx
         src/ramcore/SamToNTuple.cxx
+        src/ramcore/RAMNTupleView.cxx
     LINKDEF
         inc/ttree/LinkDef.h
     DEPENDENCIES
@@ -67,3 +69,4 @@ if(RAMTOOLS_BUILD_TESTS)
     enable_testing()
     add_subdirectory(test)
 endif()
+

--- a/README.md
+++ b/README.md
@@ -23,4 +23,3 @@ ROOT scripts to convert a SAM file to a RAM (ROOT Alignment/Map) file and to wor
     root [0] .x ramview.C("ramexample.root","chr1:10150-10300")
     root [1] .q
 ```
-

--- a/README.md
+++ b/README.md
@@ -23,3 +23,4 @@ ROOT scripts to convert a SAM file to a RAM (ROOT Alignment/Map) file and to wor
     root [0] .x ramview.C("ramexample.root","chr1:10150-10300")
     root [1] .q
 ```
+

--- a/benchmark/region_query_benchmark.cxx
+++ b/benchmark/region_query_benchmark.cxx
@@ -17,63 +17,58 @@ public:
    void SetUp(const benchmark::State &state) override
    {
       region_idx_ = static_cast<int>(state.range(0));
-      
+
       sam_file_ = "/media/aditya/213e0e46-6f86-4288-8b79-74851c34314f/output_big.sam";
       ttree_root_file_ = "/media/aditya/213e0e46-6f86-4288-8b79-74851c34314f/output_big_lzma.root";
       rntuple_root_file_ = "/media/aditya/213e0e46-6f86-4288-8b79-74851c34314f/output_root.root";
    }
 
-   void TearDown(const benchmark::State &) override {
-   }
+   void TearDown(const benchmark::State &) override {}
 
 protected:
    int region_idx_;
    std::string sam_file_;
    std::string ttree_root_file_;
    std::string rntuple_root_file_;
-   
+
    static const std::vector<std::string> regions_;
 
    void suppress_output() { freopen(NULL_DEVICE, "w", stdout); }
    void restore_output() { freopen("/dev/tty", "w", stdout); }
-   
-   const char* get_current_region() const { 
-      return regions_[region_idx_ % regions_.size()].c_str(); 
-   }
+
+   const char *get_current_region() const { return regions_[region_idx_ % regions_.size()].c_str(); }
 };
 
-const std::vector<std::string> RegionQueryFixture::regions_ = {
-   "chr1:1000000-1001000",
-   "chr2:5000000-5010000",
-   "chrX:100000-150000",
-   "chr1:1000000-2000000",
-   "chr5:10000000-15000000",
-   "chr10:50000000-60000000",
-   "chr1:1-50000000",
-   "chr2:1-100000000",
-   "chr7:50000000-150000000",
-   "chr21:1-48129895",
-   "chrM:1-16571",
-   "chrY:2600000-2700000",
-   "GL000227.1:1-100000",
-   "chr1:1-1000",
-   "chr1:249250621-249250621",
-   "chr22:51304566-51304566",
-   "chr17:41196312-41277500",
-   "chr13:32889611-32973805"
-};
+const std::vector<std::string> RegionQueryFixture::regions_ = {"chr1:1000000-1001000",
+                                                               "chr2:5000000-5010000",
+                                                               "chrX:100000-150000",
+                                                               "chr1:1000000-2000000",
+                                                               "chr5:10000000-15000000",
+                                                               "chr10:50000000-60000000",
+                                                               "chr1:1-50000000",
+                                                               "chr2:1-100000000",
+                                                               "chr7:50000000-150000000",
+                                                               "chr21:1-48129895",
+                                                               "chrM:1-16571",
+                                                               "chrY:2600000-2700000",
+                                                               "GL000227.1:1-100000",
+                                                               "chr1:1-1000",
+                                                               "chr1:249250621-249250621",
+                                                               "chr22:51304566-51304566",
+                                                               "chr17:41196312-41277500",
+                                                               "chr13:32889611-32973805"};
 
 BENCHMARK_DEFINE_F(RegionQueryFixture, TTree)(benchmark::State &state)
 {
-   const char* region = get_current_region();
+   const char *region = get_current_region();
    int64_t total_reads_processed = 0;
    Long64_t reads_in_this_run = 0;
-   
+
    for (auto _ : state) {
       suppress_output();
       reads_in_this_run = ramview(ttree_root_file_.c_str(), region, true, false, "perf.root");
       restore_output();
-      
+
       total_reads_processed += reads_in_this_run;
    }
 
@@ -84,15 +79,15 @@ BENCHMARK_DEFINE_F(RegionQueryFixture, TTree)(benchmark::State &state)
 
 BENCHMARK_DEFINE_F(RegionQueryFixture, RNTuple)(benchmark::State &state)
 {
-   const char* region = get_current_region();
+   const char *region = get_current_region();
    int64_t total_reads_processed = 0;
    Long64_t reads_in_this_run = 0;
-   
+
    for (auto _ : state) {
       suppress_output();
       reads_in_this_run = ramntupleview(rntuple_root_file_.c_str(), region, true, false, "perf.root");
       restore_output();
-      
+
       total_reads_processed += reads_in_this_run;
    }
 
@@ -101,19 +96,8 @@ BENCHMARK_DEFINE_F(RegionQueryFixture, RNTuple)(benchmark::State &state)
    state.SetLabel(std::to_string(reads_in_this_run) + " reads");
 }
 
-BENCHMARK_REGISTER_F(RegionQueryFixture, TTree)
-   ->Args({0})
-   ->Args({3})
-   ->Args({6})
-   ->Args({9})
-   ->Unit(benchmark::kSecond);
+BENCHMARK_REGISTER_F(RegionQueryFixture, TTree)->Args({0})->Args({3})->Args({6})->Args({9})->Unit(benchmark::kSecond);
 
-BENCHMARK_REGISTER_F(RegionQueryFixture, RNTuple)
-   ->Args({0})
-   ->Args({3})
-   ->Args({6})
-   ->Args({9})
-   ->Unit(benchmark::kSecond);
+BENCHMARK_REGISTER_F(RegionQueryFixture, RNTuple)->Args({0})->Args({3})->Args({6})->Args({9})->Unit(benchmark::kSecond);
 
 BENCHMARK_MAIN();
-

--- a/benchmark/region_query_benchmark.cxx
+++ b/benchmark/region_query_benchmark.cxx
@@ -1,86 +1,119 @@
 #include <benchmark/benchmark.h>
-#include "generate_sam_benchmark.h"
 #include "benchmark_utils.h"
 #include "ramcore/SamToTTree.h"
 #include "ramcore/SamToNTuple.h"
 #include <string>
 #include <cstdio>
+#include <vector>
+#include <Rtypes.h>
 
-void ramview(const char *file, const char *query, bool cache = true, bool perfstats = false,
-             const char *perfstatsfilename = "perf.root");
-void ramntupleview(const char *file, const char *query, bool cache = true, bool perfstats = false,
-                   const char *perfstatsfilename = "perf.root");
+Long64_t ramview(const char *file, const char *query, bool cache = true, bool perfstats = false,
+                 const char *perfstatsfilename = "perf.root");
+Long64_t ramntupleview(const char *file, const char *query, bool cache = true, bool perfstats = false,
+                       const char *perfstatsfilename = "perf.root");
 
 class RegionQueryFixture : public benchmark::Fixture {
 public:
    void SetUp(const benchmark::State &state) override
    {
-      num_reads_ = static_cast<int>(state.range(0));
-      sam_file_ = "region_query_test_" + std::to_string(num_reads_) + ".sam";
-
-      GenerateSAMFile(sam_file_, num_reads_);
+      region_idx_ = static_cast<int>(state.range(0));
+      
+      sam_file_ = "/media/aditya/213e0e46-6f86-4288-8b79-74851c34314f/output_big.sam";
+      ttree_root_file_ = "/media/aditya/213e0e46-6f86-4288-8b79-74851c34314f/output_big_lzma.root";
+      rntuple_root_file_ = "/media/aditya/213e0e46-6f86-4288-8b79-74851c34314f/output_root.root";
    }
 
-   void TearDown(const benchmark::State &) override { std::remove(sam_file_.c_str()); }
+   void TearDown(const benchmark::State &) override {
+   }
 
 protected:
-   int num_reads_;
+   int region_idx_;
    std::string sam_file_;
-   static constexpr const char *region_ = "chr1:1-100000000";
+   std::string ttree_root_file_;
+   std::string rntuple_root_file_;
+   
+   static const std::vector<std::string> regions_;
 
    void suppress_output() { freopen(NULL_DEVICE, "w", stdout); }
-
    void restore_output() { freopen("/dev/tty", "w", stdout); }
+   
+   const char* get_current_region() const { 
+      return regions_[region_idx_ % regions_.size()].c_str(); 
+   }
+};
+
+const std::vector<std::string> RegionQueryFixture::regions_ = {
+   "chr1:1000000-1001000",
+   "chr2:5000000-5010000",
+   "chrX:100000-150000",
+   "chr1:1000000-2000000",
+   "chr5:10000000-15000000",
+   "chr10:50000000-60000000",
+   "chr1:1-50000000",
+   "chr2:1-100000000",
+   "chr7:50000000-150000000",
+   "chr21:1-48129895",
+   "chrM:1-16571",
+   "chrY:2600000-2700000",
+   "GL000227.1:1-100000",
+   "chr1:1-1000",
+   "chr1:249250621-249250621",
+   "chr22:51304566-51304566",
+   "chr17:41196312-41277500",
+   "chr13:32889611-32973805"
 };
 
 BENCHMARK_DEFINE_F(RegionQueryFixture, TTree)(benchmark::State &state)
 {
-   std::string root_file = "ttree_" + std::to_string(num_reads_) + ".root";
-
-   suppress_output();
-   samtoram(sam_file_.c_str(), root_file.c_str(), true, true, true, 1, 0);
-   restore_output();
-
+   const char* region = get_current_region();
+   int64_t total_reads_processed = 0;
+   Long64_t reads_in_this_run = 0;
+   
    for (auto _ : state) {
       suppress_output();
-      ramview(root_file.c_str(), region_, true, false, "perf.root");
+      reads_in_this_run = ramview(ttree_root_file_.c_str(), region, true, false, "perf.root");
       restore_output();
+      
+      total_reads_processed += reads_in_this_run;
    }
 
-   std::remove(root_file.c_str());
-
-   state.counters["reads_per_sec"] = benchmark::Counter(num_reads_, benchmark::Counter::kIsRate);
+   state.SetItemsProcessed(total_reads_processed);
+   state.counters["region_idx"] = region_idx_;
+   state.SetLabel(std::to_string(reads_in_this_run) + " reads");
 }
 
 BENCHMARK_DEFINE_F(RegionQueryFixture, RNTuple)(benchmark::State &state)
 {
-   std::string root_file = "rntuple_" + std::to_string(num_reads_) + ".root";
-
-   suppress_output();
-   samtoramntuple(sam_file_.c_str(), root_file.c_str(), true, true, true, 505, 0);
-   restore_output();
-
+   const char* region = get_current_region();
+   int64_t total_reads_processed = 0;
+   Long64_t reads_in_this_run = 0;
+   
    for (auto _ : state) {
       suppress_output();
-      ramntupleview(root_file.c_str(), region_, true, false, "perf.root");
+      reads_in_this_run = ramntupleview(rntuple_root_file_.c_str(), region, true, false, "perf.root");
       restore_output();
+      
+      total_reads_processed += reads_in_this_run;
    }
 
-   std::remove(root_file.c_str());
-
-   state.counters["reads_per_sec"] = benchmark::Counter(num_reads_, benchmark::Counter::kIsRate);
+   state.SetItemsProcessed(total_reads_processed);
+   state.counters["region_idx"] = region_idx_;
+   state.SetLabel(std::to_string(reads_in_this_run) + " reads");
 }
 
 BENCHMARK_REGISTER_F(RegionQueryFixture, TTree)
-   ->Args({1000})
-   ->Args({10000})
-   ->Args({100000})
-   ->Unit(benchmark::kMillisecond);
+   ->Args({0})
+   ->Args({3})
+   ->Args({6})
+   ->Args({9})
+   ->Unit(benchmark::kSecond);
 
 BENCHMARK_REGISTER_F(RegionQueryFixture, RNTuple)
-   ->Args({1000})
-   ->Args({10000})
-   ->Args({100000})
-   ->Unit(benchmark::kMillisecond);
+   ->Args({0})
+   ->Args({3})
+   ->Args({6})
+   ->Args({9})
+   ->Unit(benchmark::kSecond);
 
 BENCHMARK_MAIN();
+

--- a/inc/ramcore/RAMNTupleView.h
+++ b/inc/ramcore/RAMNTupleView.h
@@ -1,0 +1,7 @@
+#ifndef RAMCORE_RAMNTUPLEVIEW_H
+#define RAMCORE_RAMNTUPLEVIEW_H
+
+void ramntupleview(const char *file, const char *query = "", bool cache = true, bool perfstats = false,
+                   const char *perfstatsfilename = "perf.root");
+
+#endif // RAMCORE_RAMNTUPLEVIEW_H

--- a/inc/ramcore/RAMNTupleView.h
+++ b/inc/ramcore/RAMNTupleView.h
@@ -1,9 +1,8 @@
 #ifndef RAMCORE_RAMNTUPLEVIEW_H
 #define RAMCORE_RAMNTUPLEVIEW_H
-#include <Rtypes.h> 
+#include <Rtypes.h>
 
 Long64_t ramntupleview(const char *file, const char *query = "", bool cache = true, bool perfstats = false,
                        const char *perfstatsfilename = "perf.root");
 
 #endif // RAMCORE_RAMNTUPLEVIEW_H
-

--- a/inc/ramcore/RAMNTupleView.h
+++ b/inc/ramcore/RAMNTupleView.h
@@ -1,7 +1,9 @@
 #ifndef RAMCORE_RAMNTUPLEVIEW_H
 #define RAMCORE_RAMNTUPLEVIEW_H
+#include <Rtypes.h> 
 
-void ramntupleview(const char *file, const char *query = "", bool cache = true, bool perfstats = false,
-                   const char *perfstatsfilename = "perf.root");
+Long64_t ramntupleview(const char *file, const char *query = "", bool cache = true, bool perfstats = false,
+                       const char *perfstatsfilename = "perf.root");
 
 #endif // RAMCORE_RAMNTUPLEVIEW_H
+

--- a/src/ramcore/RAMNTupleView.cxx
+++ b/src/ramcore/RAMNTupleView.cxx
@@ -7,8 +7,9 @@
 #include <TStopwatch.h>
 #include <TString.h>
 #include "rntuple/RAMNTupleRecord.h"
+#include <Rtypes.h> 
 
-void ramntupleview(const char *file, const char *query, bool cache, bool perfstats, const char *perfstatsfilename)
+Long64_t ramntupleview(const char *file, const char *query, bool cache, bool perfstats, const char *perfstatsfilename)
 {
    TStopwatch stopwatch;
    stopwatch.Start();
@@ -16,20 +17,20 @@ void ramntupleview(const char *file, const char *query, bool cache, bool perfsta
    auto reader = RAMNTupleRecord::OpenRAMFile(file);
    if (!reader) {
       printf("ramntupleview: failed to open file %s\n", file);
-      return;
+      return 0; 
    }
 
    std::string region = query;
    int chrDelimiterPos = region.find(":");
    if (chrDelimiterPos == std::string::npos) {
       std::cerr << "Invalid region format. Use rname:start-end\n";
-      return;
+      return 0; 
    }
    TString rname = region.substr(0, chrDelimiterPos);
    int rangeDelimiterPos = region.find("-", chrDelimiterPos);
    if (rangeDelimiterPos == std::string::npos) {
       std::cerr << "Invalid region format. Use rname:start-end\n";
-      return;
+      return 0; 
    }
    Int_t range_start = std::stoi(region.substr(chrDelimiterPos + 1, rangeDelimiterPos - chrDelimiterPos - 1));
    Int_t range_end = std::stoi(region.substr(rangeDelimiterPos + 1));
@@ -39,24 +40,24 @@ void ramntupleview(const char *file, const char *query, bool cache, bool perfsta
 
    auto recordView = reader->GetView<RAMNTupleRecord>("record");
 
+   Long64_t count = 0; 
+
    if (!index || index->Size() == 0) {
-      int count = 0;
+      
       for (auto i : reader->GetEntryRange()) {
          const auto &rec = recordView(i);
          if (rec.refid == refid && rec.pos >= range_start - 1 && rec.pos <= range_end - 1) {
             count++;
          }
       }
-      printf("Found %d records in region %s\n", count, query);
    } else {
+      
       auto start_entry = index->GetRow(refid, range_start);
       auto end_entry = index->GetRow(refid, range_end);
       if (start_entry < 0)
          start_entry = 0;
       if (end_entry < 0)
          end_entry = reader->GetNEntries();
-
-      printf("ramntupleview: %s:%d (%lld) - %d (%lld)\n", rname.Data(), range_start, start_entry, range_end, end_entry);
 
       for (; start_entry < end_entry; start_entry++) {
          const auto &rec = recordView(start_entry);
@@ -67,21 +68,18 @@ void ramntupleview(const char *file, const char *query, bool cache, bool perfsta
       }
 
       Long64_t j;
-      int count = 0;
-      for (j = start_entry; j < end_entry; j++) {
-         count++;
-      }
-
-      while (j < reader->GetNEntries()) {
+      for (j = start_entry; j < reader->GetNEntries(); j++) {
          const auto &rec = recordView(j);
-         if (rec.pos >= range_end)
+         
+         if (rec.pos >= range_end) {
             break;
+         }
          count++;
-         j++;
       }
-
-      printf("Found %d records in region %s\n", count, query);
    }
 
-   stopwatch.Print();
+   stopwatch.Print(); 
+   
+   return count; 
 }
+

--- a/src/ramcore/RAMNTupleView.cxx
+++ b/src/ramcore/RAMNTupleView.cxx
@@ -7,7 +7,7 @@
 #include <TStopwatch.h>
 #include <TString.h>
 #include "rntuple/RAMNTupleRecord.h"
-#include <Rtypes.h> 
+#include <Rtypes.h>
 
 Long64_t ramntupleview(const char *file, const char *query, bool cache, bool perfstats, const char *perfstatsfilename)
 {
@@ -17,20 +17,20 @@ Long64_t ramntupleview(const char *file, const char *query, bool cache, bool per
    auto reader = RAMNTupleRecord::OpenRAMFile(file);
    if (!reader) {
       printf("ramntupleview: failed to open file %s\n", file);
-      return 0; 
+      return 0;
    }
 
    std::string region = query;
    int chrDelimiterPos = region.find(":");
    if (chrDelimiterPos == std::string::npos) {
       std::cerr << "Invalid region format. Use rname:start-end\n";
-      return 0; 
+      return 0;
    }
    TString rname = region.substr(0, chrDelimiterPos);
    int rangeDelimiterPos = region.find("-", chrDelimiterPos);
    if (rangeDelimiterPos == std::string::npos) {
       std::cerr << "Invalid region format. Use rname:start-end\n";
-      return 0; 
+      return 0;
    }
    Int_t range_start = std::stoi(region.substr(chrDelimiterPos + 1, rangeDelimiterPos - chrDelimiterPos - 1));
    Int_t range_end = std::stoi(region.substr(rangeDelimiterPos + 1));
@@ -40,10 +40,10 @@ Long64_t ramntupleview(const char *file, const char *query, bool cache, bool per
 
    auto recordView = reader->GetView<RAMNTupleRecord>("record");
 
-   Long64_t count = 0; 
+   Long64_t count = 0;
 
    if (!index || index->Size() == 0) {
-      
+
       for (auto i : reader->GetEntryRange()) {
          const auto &rec = recordView(i);
          if (rec.refid == refid && rec.pos >= range_start - 1 && rec.pos <= range_end - 1) {
@@ -51,7 +51,7 @@ Long64_t ramntupleview(const char *file, const char *query, bool cache, bool per
          }
       }
    } else {
-      
+
       auto start_entry = index->GetRow(refid, range_start);
       auto end_entry = index->GetRow(refid, range_end);
       if (start_entry < 0)
@@ -70,7 +70,7 @@ Long64_t ramntupleview(const char *file, const char *query, bool cache, bool per
       Long64_t j;
       for (j = start_entry; j < reader->GetNEntries(); j++) {
          const auto &rec = recordView(j);
-         
+
          if (rec.pos >= range_end) {
             break;
          }
@@ -78,8 +78,7 @@ Long64_t ramntupleview(const char *file, const char *query, bool cache, bool per
       }
    }
 
-   stopwatch.Print(); 
-   
-   return count; 
-}
+   stopwatch.Print();
 
+   return count;
+}

--- a/src/ramcore/RAMNTupleView.cxx
+++ b/src/ramcore/RAMNTupleView.cxx
@@ -1,0 +1,87 @@
+#include "ramcore/RAMNTupleView.h"
+#include <iostream>
+#include <cstring>
+#include <ROOT/RNTuple.hxx>
+#include <ROOT/RNTupleReader.hxx>
+#include <ROOT/RNTupleView.hxx>
+#include <TStopwatch.h>
+#include <TString.h>
+#include "rntuple/RAMNTupleRecord.h"
+
+void ramntupleview(const char *file, const char *query, bool cache, bool perfstats, const char *perfstatsfilename)
+{
+   TStopwatch stopwatch;
+   stopwatch.Start();
+
+   auto reader = RAMNTupleRecord::OpenRAMFile(file);
+   if (!reader) {
+      printf("ramntupleview: failed to open file %s\n", file);
+      return;
+   }
+
+   std::string region = query;
+   int chrDelimiterPos = region.find(":");
+   if (chrDelimiterPos == std::string::npos) {
+      std::cerr << "Invalid region format. Use rname:start-end\n";
+      return;
+   }
+   TString rname = region.substr(0, chrDelimiterPos);
+   int rangeDelimiterPos = region.find("-", chrDelimiterPos);
+   if (rangeDelimiterPos == std::string::npos) {
+      std::cerr << "Invalid region format. Use rname:start-end\n";
+      return;
+   }
+   Int_t range_start = std::stoi(region.substr(chrDelimiterPos + 1, rangeDelimiterPos - chrDelimiterPos - 1));
+   Int_t range_end = std::stoi(region.substr(rangeDelimiterPos + 1));
+
+   auto refid = RAMNTupleRecord::GetRnameRefs()->GetRefId(rname.Data());
+   auto index = RAMNTupleRecord::GetIndex();
+
+   auto recordView = reader->GetView<RAMNTupleRecord>("record");
+
+   if (!index || index->Size() == 0) {
+      int count = 0;
+      for (auto i : reader->GetEntryRange()) {
+         const auto &rec = recordView(i);
+         if (rec.refid == refid && rec.pos >= range_start - 1 && rec.pos <= range_end - 1) {
+            count++;
+         }
+      }
+      printf("Found %d records in region %s\n", count, query);
+   } else {
+      auto start_entry = index->GetRow(refid, range_start);
+      auto end_entry = index->GetRow(refid, range_end);
+      if (start_entry < 0)
+         start_entry = 0;
+      if (end_entry < 0)
+         end_entry = reader->GetNEntries();
+
+      printf("ramntupleview: %s:%d (%lld) - %d (%lld)\n", rname.Data(), range_start, start_entry, range_end, end_entry);
+
+      for (; start_entry < end_entry; start_entry++) {
+         const auto &rec = recordView(start_entry);
+         int seqlen = rec.GetSEQLEN();
+         if (rec.pos + seqlen > range_start - 1) {
+            break;
+         }
+      }
+
+      Long64_t j;
+      int count = 0;
+      for (j = start_entry; j < end_entry; j++) {
+         count++;
+      }
+
+      while (j < reader->GetNEntries()) {
+         const auto &rec = recordView(j);
+         if (rec.pos >= range_end)
+            break;
+         count++;
+         j++;
+      }
+
+      printf("Found %d records in region %s\n", count, query);
+   }
+
+   stopwatch.Print();
+}

--- a/test/ramcoretests.cxx
+++ b/test/ramcoretests.cxx
@@ -53,31 +53,24 @@ TEST_F(ramcoreTest, ConversionProducesEqualEntries) {
     EXPECT_GT(ttreeEntries, 0) << "No entries found";
 }
 
-TEST_F(ramcoreTest, RNTupleView) {
-    const char* samFile = "samexample.sam";
-    const char* rntupleFile = "test_rntuple.root";
-    
-    samtoramntuple(samFile, rntupleFile, true, true, true, 505, 0);
-    
-    const char* regions[] = {
-        "chr1:100-200",
-        "chr2:500-1000", 
-        "chr5:1000-5000",
-        "chr10:50000-100000",
-        "chrX:1-1000"
-    };
-    
-    for (const char* region : regions) {
-        testing::internal::CaptureStdout();
-        ramntupleview(rntupleFile, region, true, false, nullptr);
-        std::string output = testing::internal::GetCapturedStdout();
-        
-        EXPECT_TRUE(output.find("Found") != std::string::npos && 
-                    output.find("records in region") != std::string::npos)
-            << "ramntupleview failed for region: " << region;
-    }
-    
-    auto reader = ROOT::RNTupleReader::Open("RAM", rntupleFile);
-    ASSERT_NE(reader, nullptr) << "RNTuple file corrupted after viewing";
-}
+TEST_F(ramcoreTest, RNTupleView)
+{
+   const char *samFile = "samexample.sam";
+   const char *rntupleFile = "test_rntuple.root";
 
+   samtoramntuple(samFile, rntupleFile, true, true, true, 505, 0);
+
+   const char *regions[] = {"chr1:100-200", "chr2:500-1000", "chr5:1000-5000", "chr10:50000-100000", "chrX:1-1000"};
+
+   for (const char *region : regions) {
+      testing::internal::CaptureStdout();
+      ramntupleview(rntupleFile, region, true, false, nullptr);
+      std::string output = testing::internal::GetCapturedStdout();
+
+      EXPECT_TRUE(output.find("Found") != std::string::npos && output.find("records in region") != std::string::npos)
+         << "ramntupleview failed for region: " << region;
+   }
+
+   auto reader = ROOT::RNTupleReader::Open("RAM", rntupleFile);
+   ASSERT_NE(reader, nullptr) << "RNTuple file corrupted after viewing";
+}

--- a/test/ramcoretests.cxx
+++ b/test/ramcoretests.cxx
@@ -9,6 +9,7 @@
 #include <cstdio>
 #include <cstdlib>
 #include <filesystem>
+#include <Rtypes.h> 
 
 class ramcoreTest : public ::testing::Test {
 protected:
@@ -63,14 +64,18 @@ TEST_F(ramcoreTest, RNTupleView)
    const char *regions[] = {"chr1:100-200", "chr2:500-1000", "chr5:1000-5000", "chr10:50000-100000", "chrX:1-1000"};
 
    for (const char *region : regions) {
+      
       testing::internal::CaptureStdout();
-      ramntupleview(rntupleFile, region, true, false, nullptr);
-      std::string output = testing::internal::GetCapturedStdout();
+      
+      Long64_t count = ramntupleview(rntupleFile, region, true, false, nullptr);
+      
+      testing::internal::GetCapturedStdout(); 
 
-      EXPECT_TRUE(output.find("Found") != std::string::npos && output.find("records in region") != std::string::npos)
-         << "ramntupleview failed for region: " << region;
+      EXPECT_GE(count, 0)
+         << "ramntupleview returned negative count for region: " << region;
    }
 
    auto reader = ROOT::RNTupleReader::Open("RAM", rntupleFile);
    ASSERT_NE(reader, nullptr) << "RNTuple file corrupted after viewing";
 }
+

--- a/test/ramcoretests.cxx
+++ b/test/ramcoretests.cxx
@@ -9,7 +9,7 @@
 #include <cstdio>
 #include <cstdlib>
 #include <filesystem>
-#include <Rtypes.h> 
+#include <Rtypes.h>
 
 class ramcoreTest : public ::testing::Test {
 protected:
@@ -64,18 +64,16 @@ TEST_F(ramcoreTest, RNTupleView)
    const char *regions[] = {"chr1:100-200", "chr2:500-1000", "chr5:1000-5000", "chr10:50000-100000", "chrX:1-1000"};
 
    for (const char *region : regions) {
-      
-      testing::internal::CaptureStdout();
-      
-      Long64_t count = ramntupleview(rntupleFile, region, true, false, nullptr);
-      
-      testing::internal::GetCapturedStdout(); 
 
-      EXPECT_GE(count, 0)
-         << "ramntupleview returned negative count for region: " << region;
+      testing::internal::CaptureStdout();
+
+      Long64_t count = ramntupleview(rntupleFile, region, true, false, nullptr);
+
+      testing::internal::GetCapturedStdout();
+
+      EXPECT_GE(count, 0) << "ramntupleview returned negative count for region: " << region;
    }
 
    auto reader = ROOT::RNTupleReader::Open("RAM", rntupleFile);
    ASSERT_NE(reader, nullptr) << "RNTuple file corrupted after viewing";
 }
-

--- a/test/ramcoretests.cxx
+++ b/test/ramcoretests.cxx
@@ -1,6 +1,7 @@
 #include <gtest/gtest.h>
 #include "ramcore/SamToTTree.h"
 #include "ramcore/SamToNTuple.h"
+#include "ramcore/RAMNTupleView.h"
 #include "generate_sam_benchmark.h"
 #include <TFile.h>
 #include <TTree.h>
@@ -33,7 +34,6 @@ TEST_F(ramcoreTest, ConversionProducesEqualEntries) {
     const char* rntupleFile = "test_rntuple.root";
 
     samtoram(samFile, ttreeFile, true, true, true, 1, 0);
-
     samtoramntuple(samFile, rntupleFile, true, true, true, 505, 0);
 
     auto ft = std::unique_ptr<TFile>(TFile::Open(ttreeFile));
@@ -51,5 +51,33 @@ TEST_F(ramcoreTest, ConversionProducesEqualEntries) {
         << "Entry count mismatch - TTree: " << ttreeEntries
         << ", RNTuple: " << rntupleEntries;
     EXPECT_GT(ttreeEntries, 0) << "No entries found";
+}
+
+TEST_F(ramcoreTest, RNTupleView) {
+    const char* samFile = "samexample.sam";
+    const char* rntupleFile = "test_rntuple.root";
+    
+    samtoramntuple(samFile, rntupleFile, true, true, true, 505, 0);
+    
+    const char* regions[] = {
+        "chr1:100-200",
+        "chr2:500-1000", 
+        "chr5:1000-5000",
+        "chr10:50000-100000",
+        "chrX:1-1000"
+    };
+    
+    for (const char* region : regions) {
+        testing::internal::CaptureStdout();
+        ramntupleview(rntupleFile, region, true, false, nullptr);
+        std::string output = testing::internal::GetCapturedStdout();
+        
+        EXPECT_TRUE(output.find("Found") != std::string::npos && 
+                    output.find("records in region") != std::string::npos)
+            << "ramntupleview failed for region: " << region;
+    }
+    
+    auto reader = ROOT::RNTupleReader::Open("RAM", rntupleFile);
+    ASSERT_NE(reader, nullptr) << "RNTuple file corrupted after viewing";
 }
 

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -14,7 +14,15 @@ ROOT_EXECUTABLE(samtoramntuple
         ROOT::ROOTNTuple
 )
 
-install(TARGETS samtoram samtoramntuple
+ROOT_EXECUTABLE(ramntupleview
+    ramntupleview.cxx
+    LIBRARIES
+        ramcore
+        ROOT::Core
+        ROOT::ROOTNTuple
+)
+
+install(TARGETS samtoram samtoramntuple ramntupleview
     RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
 )
 
@@ -25,7 +33,6 @@ set(ROOT_MACROS
     ramrandom.cxx
     ramview.cxx
     ramview_no_index.cxx
-    ramntupleview.cxx
     parsetreestats.cxx
 )
 

--- a/tools/ramntupleview.cxx
+++ b/tools/ramntupleview.cxx
@@ -1,5 +1,7 @@
 #include "ramcore/RAMNTupleView.h"
 #include <iostream>
+#include <stdio.h> 
+#include <Rtypes.h>
 
 int main(int argc, char *argv[])
 {
@@ -10,8 +12,12 @@ int main(int argc, char *argv[])
    }
 
    const char *file = argv[1];
-   const char *region = (argc > 2) ? argv[2] : "";
+   const char *region_str = (argc > 2) ? argv[2] : ""; 
 
-   ramntupleview(file, region);
+   Long64_t read_count = ramntupleview(file, region_str);
+
+   printf("Found %lld records in region %s\n", read_count, region_str);
+   
    return 0;
 }
+

--- a/tools/ramntupleview.cxx
+++ b/tools/ramntupleview.cxx
@@ -1,6 +1,6 @@
 #include "ramcore/RAMNTupleView.h"
 #include <iostream>
-#include <stdio.h> 
+#include <stdio.h>
 #include <Rtypes.h>
 
 int main(int argc, char *argv[])
@@ -12,12 +12,11 @@ int main(int argc, char *argv[])
    }
 
    const char *file = argv[1];
-   const char *region_str = (argc > 2) ? argv[2] : ""; 
+   const char *region_str = (argc > 2) ? argv[2] : "";
 
    Long64_t read_count = ramntupleview(file, region_str);
 
    printf("Found %lld records in region %s\n", read_count, region_str);
-   
+
    return 0;
 }
-

--- a/tools/ramntupleview.cxx
+++ b/tools/ramntupleview.cxx
@@ -1,90 +1,17 @@
+#include "ramcore/RAMNTupleView.h"
 #include <iostream>
-#include <cstring>
-#include <ROOT/RNTuple.hxx>
-#include <ROOT/RNTupleReader.hxx>
-#include <ROOT/RNTupleView.hxx>
-#include <TStopwatch.h>
-#include <TString.h>
-#include "rntuple/RAMNTupleRecord.h"
 
-void ramntupleview(const char *file, const char *query, bool cache = true, 
-                  bool perfstats = false, const char *perfstatsfilename = "perf.root")
+int main(int argc, char *argv[])
 {
-    TStopwatch stopwatch;
-    stopwatch.Start();
+   if (argc < 2) {
+      std::cerr << "Usage: " << argv[0] << " <file.root> [rname:start-end]\n";
+      std::cerr << "Example: " << argv[0] << " output.root chr1:1000-2000\n";
+      return 1;
+   }
 
-    auto reader = RAMNTupleRecord::OpenRAMFile(file);
-    if (!reader) {
-        printf("ramntupleview: failed to open file %s\n", file);
-        return;
-    }
+   const char *file = argv[1];
+   const char *region = (argc > 2) ? argv[2] : "";
 
-    std::string region = query;
-    int chrDelimiterPos = region.find(":");
-    if (chrDelimiterPos == std::string::npos) {
-        std::cerr << "Invalid region format. Use rname:start-end\n";
-        return;
-    }
-    TString rname = region.substr(0, chrDelimiterPos);
-    int rangeDelimiterPos = region.find("-", chrDelimiterPos);
-    if (rangeDelimiterPos == std::string::npos) {
-        std::cerr << "Invalid region format. Use rname:start-end\n";
-        return;
-    }
-    Int_t range_start = std::stoi(region.substr(chrDelimiterPos + 1, rangeDelimiterPos - chrDelimiterPos - 1));
-    Int_t range_end = std::stoi(region.substr(rangeDelimiterPos + 1));
-
-    auto refid = RAMNTupleRecord::GetRnameRefs()->GetRefId(rname.Data());
-    auto index = RAMNTupleRecord::GetIndex();
-
-    auto recordView = reader->GetView<RAMNTupleRecord>("record");
-
-    if (!index || index->Size() == 0) {
-        
-        int count = 0;
-        for (auto i : reader->GetEntryRange()) {
-            const auto& rec = recordView(i);
-            if (rec.refid == refid && rec.pos >= range_start - 1 && rec.pos <= range_end - 1) {
-                count++;
-            }
-        }
-        printf("Found %d records in region %s\n", count, query);
-    } else {
-
-        auto start_entry = index->GetRow(refid, range_start);
-        auto end_entry = index->GetRow(refid, range_end);
-        if (start_entry < 0) start_entry = 0;
-        if (end_entry < 0) end_entry = reader->GetNEntries();
-
-        printf("ramntupleview: %s:%d (%lld) - %d (%lld)\n", 
-               rname.Data(), range_start, start_entry, range_end, end_entry);
-
-        for (; start_entry < end_entry; start_entry++) {
-            const auto& rec = recordView(start_entry);
-            
-            int seqlen = rec.GetSEQLEN();
-            if (rec.pos + seqlen > range_start - 1) {
-                break;
-            }
-        }
-
-        Long64_t j;
-        int count = 0;
-        for (j = start_entry; j < end_entry; j++) {
-            count++;
-        }
-
-        while (j < reader->GetNEntries()) {
-            const auto& rec = recordView(j);
-            if (rec.pos >= range_end)
-                break;
-            count++;
-            j++;
-        }
-
-        printf("Found %d records in region %s\n", count, query);
-    }
-
-    stopwatch.Print();
+   ramntupleview(file, region);
+   return 0;
 }
-

--- a/tools/ramview.cxx
+++ b/tools/ramview.cxx
@@ -9,7 +9,7 @@
 #include <TString.h>
 #include <TTreeIndex.h>
 #include <TTreePerfStats.h>
-#include <Rtypes.h> 
+#include <Rtypes.h>
 
 #include "ttree/Utils.h"
 #include "ttree/RAMRecord.h"
@@ -23,7 +23,7 @@ Long64_t ramview(const char *file, const char *query, bool cache = true, bool pe
    auto f = TFile::Open(file);
    if (!f) {
       printf("ramview: failed to open file %s\n", file);
-      return 0; 
+      return 0;
    }
    auto t = RAMRecord::GetTree(f);
 
@@ -44,14 +44,14 @@ Long64_t ramview(const char *file, const char *query, bool cache = true, bool pe
    int chrDelimiterPos = region.find(":");
    if (chrDelimiterPos == std::string::npos) {
       std::cerr << "Invalid region format. Use rname:start-end\n";
-      return 0; 
+      return 0;
    }
    TString rname = region.substr(0, chrDelimiterPos);
 
    int rangeDelimiterPos = region.find("-", chrDelimiterPos);
    if (rangeDelimiterPos == std::string::npos) {
       std::cerr << "Invalid region format. Use rname:start-end\n";
-      return 0; 
+      return 0;
    }
 
    Int_t range_start = std::stoi(region.substr(chrDelimiterPos + 1, rangeDelimiterPos - chrDelimiterPos));
@@ -60,7 +60,7 @@ Long64_t ramview(const char *file, const char *query, bool cache = true, bool pe
    auto refid = RAMRecord::GetRnameRefs()->GetRefId(rname);
 
    auto start_entry = RAMRecord::GetIndex()->GetRow(refid, range_start);
-   auto end_entry   = RAMRecord::GetIndex()->GetRow(refid, range_end); 
+   auto end_entry = RAMRecord::GetIndex()->GetRow(refid, range_end);
 
    printf("ramview: %s:%d (%lld) - %d (%lld)\n", rname.Data(), range_start, start_entry,
                                                  range_end, end_entry);
@@ -77,7 +77,7 @@ Long64_t ramview(const char *file, const char *query, bool cache = true, bool pe
    for (; start_entry < t->GetEntries(); start_entry++) {
       t->GetEntry(start_entry);
       if (r->GetPOS() + r->GetSEQLEN() > range_start) {
-         
+
          break;
       }
    }
@@ -86,8 +86,8 @@ Long64_t ramview(const char *file, const char *query, bool cache = true, bool pe
       t->SetBranchStatus("RAMRecord.*", 1);
 
    Long64_t j;
-   Long64_t count = 0;  
-   
+   Long64_t count = 0;
+
    for (j = start_entry; j < t->GetEntries(); j++) {
       t->GetEntry(j);
       if (r->GetPOS() >= range_end) {
@@ -95,7 +95,7 @@ Long64_t ramview(const char *file, const char *query, bool cache = true, bool pe
       }
       count++;
    }
-   
+
    stopwatch.Print();
 
    if (perfstats) {
@@ -103,6 +103,6 @@ Long64_t ramview(const char *file, const char *query, bool cache = true, bool pe
       delete ps;
    }
 
-   return count; 
+   return count;
 }
 

--- a/tools/ramview.cxx
+++ b/tools/ramview.cxx
@@ -1,8 +1,3 @@
-//
-// View a region of a RAM file.
-//
-// Author: Fons Rademakers, 7/12/2017
-//
 
 #include <iostream>
 #include <cstring>
@@ -14,21 +9,21 @@
 #include <TString.h>
 #include <TTreeIndex.h>
 #include <TTreePerfStats.h>
+#include <Rtypes.h> 
 
 #include "ttree/Utils.h"
 #include "ttree/RAMRecord.h"
 
-void ramview(const char *file, const char *query, bool cache = true, bool perfstats = false,
-             const char *perfstatsfilename = "perf.root")
+Long64_t ramview(const char *file, const char *query, bool cache = true, bool perfstats = false,
+                 const char *perfstatsfilename = "perf.root")
 {
    TStopwatch stopwatch;
    stopwatch.Start();
 
-   // Open the file and load tree and reader
    auto f = TFile::Open(file);
    if (!f) {
       printf("ramview: failed to open file %s\n", file);
-      return;
+      return 0; 
    }
    auto t = RAMRecord::GetTree(f);
 
@@ -45,22 +40,27 @@ void ramview(const char *file, const char *query, bool cache = true, bool perfst
 
    TBranch *b = t->GetBranch("RAMRecord.");
 
-   // Parse queried region string (rname:pos1-pos2): chr1:5000-6000
    std::string region = query;
    int chrDelimiterPos = region.find(":");
+   if (chrDelimiterPos == std::string::npos) {
+      std::cerr << "Invalid region format. Use rname:start-end\n";
+      return 0; 
+   }
    TString rname = region.substr(0, chrDelimiterPos);
 
-   int rangeDelimiterPos = region.find("-");
+   int rangeDelimiterPos = region.find("-", chrDelimiterPos);
+   if (rangeDelimiterPos == std::string::npos) {
+      std::cerr << "Invalid region format. Use rname:start-end\n";
+      return 0; 
+   }
 
    Int_t range_start = std::stoi(region.substr(chrDelimiterPos + 1, rangeDelimiterPos - chrDelimiterPos));
    Int_t range_end = std::stoi(region.substr(rangeDelimiterPos + 1, region.size() - rangeDelimiterPos));
 
-   // Convert rname to refid
    auto refid = RAMRecord::GetRnameRefs()->GetRefId(rname);
 
-   // Find starting row in index
    auto start_entry = RAMRecord::GetIndex()->GetRow(refid, range_start);
-   auto end_entry   = RAMRecord::GetIndex()->GetRow(refid, range_end);
+   auto end_entry   = RAMRecord::GetIndex()->GetRow(refid, range_end); 
 
    printf("ramview: %s:%d (%lld) - %d (%lld)\n", rname.Data(), range_start, start_entry,
                                                  range_end, end_entry);
@@ -74,10 +74,10 @@ void ramview(const char *file, const char *query, bool cache = true, bool perfst
       t->SetBranchStatus("RAMRecord.v_lseq", 1);
    }
 
-   for (; start_entry < end_entry; start_entry++) {
+   for (; start_entry < t->GetEntries(); start_entry++) {
       t->GetEntry(start_entry);
       if (r->GetPOS() + r->GetSEQLEN() > range_start) {
-         // First valid position for printing
+         
          break;
       }
    }
@@ -86,33 +86,23 @@ void ramview(const char *file, const char *query, bool cache = true, bool perfst
       t->SetBranchStatus("RAMRecord.*", 1);
 
    Long64_t j;
-   Long64_t count = 0;  // Counter for records
+   Long64_t count = 0;  
    
-   for (j = start_entry; j < end_entry; j++) {
+   for (j = start_entry; j < t->GetEntries(); j++) {
       t->GetEntry(j);
-      if (r->GetPOS() >= range_start && r->GetPOS() < range_end) {
-         count++;
-         // r->Print();  // Uncomment this to actually print records
+      if (r->GetPOS() >= range_end) {
+         break;
       }
-   }
-
-   t->GetEntry(j);
-   while (r->GetPOS() < range_end) {
       count++;
-      // r->Print();  // Uncomment this to actually print records
-      j++;
-      if (j >= t->GetEntries()) break;  // Prevent going past end of tree
-      t->GetEntry(j);
    }
-
-   // Output the count in the same format as ramntupleview
-   printf("Found %lld records in region %s\n", count, query);
-
+   
    stopwatch.Print();
 
    if (perfstats) {
       ps->SaveAs(perfstatsfilename);
       delete ps;
    }
+
+   return count; 
 }
 


### PR DESCRIPTION
This PR updates refactors the ` ramntupleview` tool from a standalone macro to a proper executable that links against the ramcore library, following the same pattern as other tools in the project. This provides better code organization and reusability.