### PR TITLE
 Add Code Coverage and Clang-tidy

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,72 @@
+codecov:
+  require_ci_to_pass: no
+
+coverage:
+  precision: 2
+  round: down
+  range: "70...100" 
+  
+  status:
+    project:
+      default:
+        target: auto      # Uses coverage from base commit
+        threshold: 2      # Allow 2% drop
+        
+    patch:
+      default:
+        target: 85        # New code should have 85% coverage
+        threshold: 2      # Allow 2% variance
+        
+    changes: no
+
+parsers:
+  gcov:
+    branch_detection:
+      conditional: yes
+      loop: yes
+      method: no
+      macro: no
+
+comment:
+  layout: "reach, diff, flags, tree, files"
+  behavior: default
+  require_changes: no
+
+ignore:
+  - "test/**/*"
+  
+  - "benchmark/**/*"
+  
+  - "scripts/**/*"
+  - "**/*.C"
+  
+  - "Doxyfile"
+
+# Define coverage flags for different components
+flags:
+  ramcore:
+    paths:
+      - "src/ramcore/**"
+      - "inc/ramcore/**"
+    carryforward: true
+    
+  rntuple:
+    paths:
+      - "src/rntuple/**"
+      - "inc/rntuple/**"
+    carryforward: true
+    
+  ttree:
+    paths:
+      - "src/ttree/**"
+      - "inc/ttree/**"
+    carryforward: true
+    
+  tools:
+    paths:
+      - "tools/**"
+    carryforward: true
+
+github_checks:
+  annotations: true
+

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -42,7 +42,6 @@ ignore:
   
   - "Doxyfile"
 
-# Define coverage flags for different components
 flags:
   ramcore:
     paths:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,16 +9,16 @@ on:
 jobs:
   build-and-test:
     name: Build and Test
-    runs-on: ubuntu-24.04  
+    runs-on: ubuntu-24.04
     
     steps:
-    - uses: actions/checkout@v5  
+    - uses: actions/checkout@v5
     
     - name: Install ROOT
       run: |
         ROOT_URL="https://root.cern/download/root_v6.36.00.Linux-ubuntu24.04-x86_64-gcc13.3.tar.gz"
         wget -O root.tar.gz $ROOT_URL
-        tar -xzf root.tar.gz -C /opt/  
+        tar -xzf root.tar.gz -C /opt/
         echo "/opt/root/bin" >> $GITHUB_PATH
         
     - name: Install build dependencies
@@ -29,7 +29,7 @@ jobs:
     - name: Configure CMake
       run: |
         source thisroot.sh
-        mkdir build  
+        mkdir build
         cd build
         cmake .. \
           -DCMAKE_BUILD_TYPE=Release \
@@ -49,3 +49,59 @@ jobs:
         cd build
         ctest --output-on-failure --build-config Release
 
+  coverage:
+    name: Code Coverage
+    runs-on: ubuntu-24.04
+    needs: build-and-test # Run only if build-and-test succeeds
+    
+    steps:
+    - uses: actions/checkout@v5
+    
+    - name: Install ROOT
+      run: |
+        ROOT_URL="https://root.cern/download/root_v6.36.00.Linux-ubuntu24.04-x86_64-gcc13.3.tar.gz"
+        wget -O root.tar.gz $ROOT_URL
+        tar -xzf root.tar.gz -C /opt/
+        echo "/opt/root/bin" >> $GITHUB_PATH
+        
+    - name: Install build and coverage dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y libvdt-dev libtbb-dev gcovr lcov
+        
+    - name: Configure with coverage
+      run: |
+        source thisroot.sh
+        mkdir build
+        cd build
+        cmake .. \
+          -DCMAKE_BUILD_TYPE=Debug \
+          -DENABLE_COVERAGE=ON \
+          -DRAMTOOLS_BUILD_TESTS=ON \
+          -DRAMTOOLS_BUILD_TOOLS=ON \
+          -DRAMTOOLS_BUILD_BENCHMARKS=OFF
+        
+    - name: Build
+      run: |
+        source thisroot.sh
+        cd build
+        cmake --build . --config Debug -j $(nproc)
+      
+    - name: Run tests
+      run: |
+        source thisroot.sh
+        cd build
+        ctest --output-on-failure --build-config Debug
+        
+    - name: Generate coverage report
+      run: |
+        cd build
+        gcovr -r .. --xml-pretty --xml coverage.xml --print-summary
+        
+    - name: Upload coverage to Codecov
+      uses: codecov/codecov-action@v4
+      with:
+        files: ./build/coverage.xml
+        flags: unittests
+        name: codecov-ramtools
+        fail_ci_if_error: false

--- a/.github/workflows/clang-tidy-review-post.yml
+++ b/.github/workflows/clang-tidy-review-post.yml
@@ -1,0 +1,36 @@
+name: Post clang-tidy review comments
+
+on:
+  workflow_run:
+    workflows: ["clang-tidy-review"]
+    types:
+      - completed
+
+permissions:
+  checks: write
+  pull-requests: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.workflow_run.pull_requests[0].number }}
+  cancel-in-progress: true
+
+jobs:
+  post-comments:
+    # Only run if the triggering workflow was from a pull request
+    if: github.event.workflow_run.event == 'pull_request'
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: Post review comments
+        id: post-review
+        uses: ZedThree/clang-tidy-review/post@v0.21.0
+        with:
+          max_comments: 10
+          
+      # Fail if there are any clang-tidy warnings
+      - name: Check for issues
+        if: steps.post-review.outputs.total_comments > 0
+        run: |
+          echo "::error::Found ${{ steps.post-review.outputs.total_comments }} clang-tidy issues"
+          exit 1
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,7 +74,9 @@ if(RAMTOOLS_BUILD_TOOLS)
     add_subdirectory(tools)
 endif()
 
-if(RAMTOOLS_BUILD_BENCHMARKS)
+# Include benchmark directory if benchmarks OR tests are enabled
+# (sam_generator is needed by tests)
+if(RAMTOOLS_BUILD_BENCHMARKS OR RAMTOOLS_BUILD_TESTS)
     add_subdirectory(benchmark)
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,7 +86,7 @@ if(RAMTOOLS_BUILD_TESTS)
         add_custom_target(coverage
             COMMAND ${CMAKE_CTEST_COMMAND} --output-on-failure
             COMMAND gcovr -r ${CMAKE_SOURCE_DIR} --html --html-details -o ${CMAKE_BINARY_DIR}/coverage.html
-            COMMAND gcovr -r ${CMAKE_SOURCE_DIR} --xml -o ${CMAKE_BINARY_DIR}/coverage.xml
+            COMMAND gcovr -r ${CMAKE_SOURCE_DIR} --xml-pretty --xml coverage.xml
             WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
             COMMENT "Running tests and generating code coverage report..."
         )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,7 +86,7 @@ if(RAMTOOLS_BUILD_TESTS)
         add_custom_target(coverage
             COMMAND ${CMAKE_CTEST_COMMAND} --output-on-failure
             COMMAND gcovr -r ${CMAKE_SOURCE_DIR} --html --html-details -o ${CMAKE_BINARY_DIR}/coverage.html
-            COMMAND gcovr -r ${CMAKE_SOURCE_DIR} --xml-pretty --xml coverage.xml
+            COMMAND gcovr -r ${CMAKE_SOURCE_DIR} --xml -o ${CMAKE_BINARY_DIR}/coverage.xml
             WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
             COMMENT "Running tests and generating code coverage report..."
         )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,19 @@ set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 option(RAMTOOLS_BUILD_TESTS "Build unit tests" ON)
 option(RAMTOOLS_BUILD_BENCHMARKS "Build benchmarks" ON)
 option(RAMTOOLS_BUILD_TOOLS "Build tools" ON)
+option(ENABLE_COVERAGE "Enable code coverage reporting" OFF)
+
+if(ENABLE_COVERAGE)
+    if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
+        message(STATUS "Code coverage enabled")
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} --coverage -fprofile-arcs -ftest-coverage")
+        set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} --coverage -fprofile-arcs -ftest-coverage")
+        set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} --coverage")
+        set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} --coverage")
+    else()
+        message(WARNING "Code coverage requires GCC or Clang")
+    endif()
+endif()
 
 set(ROOT_MIN_VERSION 6.26)
 find_package(ROOT ${ROOT_MIN_VERSION} REQUIRED COMPONENTS Core RIO Tree ROOTNTuple ROOTNTupleUtil)
@@ -20,7 +33,7 @@ include(GNUInstallDirs)
 set(CMAKE_INSTALL_LIBDIR lib)
 set(CMAKE_INSTALL_INCLUDEDIR include)
 
-    ROOT_STANDARD_LIBRARY_PACKAGE(ramcore
+ROOT_STANDARD_LIBRARY_PACKAGE(ramcore
     HEADERS
         inc/ttree/RAMRecord.h
         inc/ttree/Utils.h
@@ -68,5 +81,15 @@ endif()
 if(RAMTOOLS_BUILD_TESTS)
     enable_testing()
     add_subdirectory(test)
+    
+    if(ENABLE_COVERAGE)
+        add_custom_target(coverage
+            COMMAND ${CMAKE_CTEST_COMMAND} --output-on-failure
+            COMMAND gcovr -r ${CMAKE_SOURCE_DIR} --html --html-details -o ${CMAKE_BINARY_DIR}/coverage.html
+            COMMAND gcovr -r ${CMAKE_SOURCE_DIR} --xml-pretty --xml coverage.xml
+            WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+            COMMENT "Running tests and generating code coverage report..."
+        )
+    endif()
 endif()
 

--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -1,79 +1,80 @@
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake/modules)
-include(GoogleBenchmark)
 
-add_library(sam_generator STATIC 
-    generate_sam_benchmark.cxx
-)
+if(RAMTOOLS_BUILD_TESTS OR RAMTOOLS_BUILD_BENCHMARKS)
+    add_library(sam_generator STATIC 
+        generate_sam.cxx  
+    )
 
-target_include_directories(sam_generator PUBLIC
-    ${CMAKE_CURRENT_SOURCE_DIR}
-)
+    target_include_directories(sam_generator PUBLIC
+        ${CMAKE_CURRENT_SOURCE_DIR}
+    )
+endif()
 
-target_link_libraries(sam_generator PRIVATE 
-    benchmark::benchmark
-)
+if(RAMTOOLS_BUILD_BENCHMARKS)
+    include(GoogleBenchmark)
+    
+    add_library(ramtools_views STATIC
+        ${CMAKE_SOURCE_DIR}/tools/ramview.cxx
+        ${CMAKE_SOURCE_DIR}/tools/ramntupleview.cxx
+    )
 
-add_library(ramtools_views STATIC
-    ${CMAKE_SOURCE_DIR}/tools/ramview.cxx
-    ${CMAKE_SOURCE_DIR}/tools/ramntupleview.cxx
-)
+    target_link_libraries(ramtools_views PRIVATE 
+        ramcore 
+        ROOT::TreePlayer
+    )
 
-target_link_libraries(ramtools_views PRIVATE 
-    ramcore 
-    ROOT::TreePlayer
-)
+    ROOT_EXECUTABLE(sam_to_ram_benchmark
+        sam_to_ram_benchmark.cxx
+        LIBRARIES
+            benchmark::benchmark
+            ramcore
+            sam_generator
+    )
 
-ROOT_EXECUTABLE(sam_to_ram_benchmark
-    sam_to_ram_benchmark.cxx
-    LIBRARIES
-        benchmark::benchmark
-        ramcore
-        sam_generator
-)
+    ROOT_EXECUTABLE(conversion_time_benchmark
+        conversion_time_benchmark.cxx
+        LIBRARIES
+            benchmark::benchmark
+            ramcore
+            sam_generator
+    )
 
-ROOT_EXECUTABLE(conversion_time_benchmark
-    conversion_time_benchmark.cxx
-    LIBRARIES
-        benchmark::benchmark
-        ramcore
-        sam_generator
-)
+    ROOT_EXECUTABLE(region_query_benchmark
+        region_query_benchmark.cxx
+        LIBRARIES
+            benchmark::benchmark
+            ramcore
+            sam_generator
+            ramtools_views
+    )
 
-ROOT_EXECUTABLE(region_query_benchmark
-    region_query_benchmark.cxx
-    LIBRARIES
-        benchmark::benchmark
-        ramcore
-        sam_generator
-        ramtools_views
-)
+    ROOT_EXECUTABLE(chromosome_split_benchmark
+        chromosome_split_benchmark.cxx
+        LIBRARIES
+            benchmark::benchmark
+            ramcore
+            sam_generator
+    )
 
-ROOT_EXECUTABLE(chromosome_split_benchmark
-    chromosome_split_benchmark.cxx
-    LIBRARIES
-        benchmark::benchmark
-        ramcore
-        sam_generator
-)
+    install(TARGETS sam_to_ram_benchmark conversion_time_benchmark region_query_benchmark chromosome_split_benchmark
+        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+    )
 
-install(TARGETS sam_to_ram_benchmark conversion_time_benchmark region_query_benchmark chromosome_split_benchmark
-    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
-)
-
-add_custom_target(benchmark
-    COMMAND ${CMAKE_COMMAND} -E echo "=== SAM to RAM Benchmark ==="
-    COMMAND sam_to_ram_benchmark
-    COMMAND ${CMAKE_COMMAND} -E echo ""
-    COMMAND ${CMAKE_COMMAND} -E echo "=== Conversion Time Benchmark ==="
-    COMMAND conversion_time_benchmark
-    COMMAND ${CMAKE_COMMAND} -E echo ""
-    COMMAND ${CMAKE_COMMAND} -E echo "=== Region Query Benchmark ==="
-    COMMAND region_query_benchmark
-    COMMAND ${CMAKE_COMMAND} -E echo ""
-    COMMAND ${CMAKE_COMMAND} -E echo "=== Chromosome Split Benchmark ==="
-    COMMAND chromosome_split_benchmark
-    DEPENDS sam_to_ram_benchmark conversion_time_benchmark region_query_benchmark chromosome_split_benchmark
-    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-    COMMENT "Running all RAM tools benchmarks"
-)
+    add_custom_target(benchmark
+        COMMAND ${CMAKE_COMMAND} -E echo "=== SAM to RAM Benchmark ==="
+        COMMAND sam_to_ram_benchmark
+        COMMAND ${CMAKE_COMMAND} -E echo ""
+        COMMAND ${CMAKE_COMMAND} -E echo "=== Conversion Time Benchmark ==="
+        COMMAND conversion_time_benchmark
+        COMMAND ${CMAKE_COMMAND} -E echo ""
+        COMMAND ${CMAKE_COMMAND} -E echo "=== Region Query Benchmark ==="
+        COMMAND region_query_benchmark
+        COMMAND ${CMAKE_COMMAND} -E echo ""
+        COMMAND ${CMAKE_COMMAND} -E echo "=== Chromosome Split Benchmark ==="
+        COMMAND chromosome_split_benchmark
+        DEPENDS sam_to_ram_benchmark conversion_time_benchmark region_query_benchmark chromosome_split_benchmark
+        WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+        COMMENT "Running all RAM tools benchmarks"
+    )
+endif()
 

--- a/benchmark/generate_sam.cxx
+++ b/benchmark/generate_sam.cxx
@@ -1,0 +1,70 @@
+#include "generate_sam_benchmark.h"
+#include <fstream>
+#include <random>
+#include <vector>
+#include <string>
+#include <iostream>
+
+#ifndef BASE_SAM_READS
+#define BASE_SAM_READS 100
+#endif
+
+void GenerateSAMFile(const std::string &filename, int num_reads)
+{
+   std::mt19937 rng(42);
+   std::vector<std::pair<std::string, int>> chromosomes = {
+      {"chr1", 249250621},  {"chr2", 243199373},  {"chr3", 198022430},  {"chr4", 191154276},  {"chr5", 180915260},
+      {"chr6", 171115067},  {"chr7", 159138663},  {"chr8", 146364022},  {"chr9", 141213431},  {"chr10", 135534747},
+      {"chr11", 135006516}, {"chr12", 133851895}, {"chr13", 115169878}, {"chr14", 107349540}, {"chr15", 102531392},
+      {"chr16", 90354753},  {"chr17", 81195210},  {"chr18", 78077248},  {"chr19", 59128983},  {"chr20", 63025520},
+      {"chr21", 48129895},  {"chr22", 51304566},  {"chrM", 16571},      {"chrX", 155270560}};
+
+   const char bases[4] = {'A', 'C', 'G', 'T'};
+   std::ofstream out(filename);
+   for (const auto &[chrom, length] : chromosomes) {
+      out << "@SQ\tSN:" << chrom << "\tLN:" << length << "\n";
+   }
+
+   std::uniform_int_distribution<> base_dist(0, 3);
+   std::uniform_int_distribution<> flag_dist(0, 1);
+   std::uniform_int_distribution<> chrom_dist(0, chromosomes.size() - 1);
+   std::uniform_int_distribution<> qual_dist(33, 73);
+   std::uniform_int_distribution<> fc_dist(10000, 99999);
+   std::uniform_int_distribution<> lane_dist(1, 8);
+   std::uniform_int_distribution<> tile_dist(1, 300);
+   std::uniform_int_distribution<> coord_dist(1, 1000);
+   std::uniform_int_distribution<> mismatch_dist(0, 9);
+
+   for (int i = 0; i < num_reads; ++i) {
+      auto [chrom, chrom_length] = chromosomes[chrom_dist(rng)];
+      int read_length = 36;
+      std::uniform_int_distribution<> pos_dist(1, std::max(1, chrom_length - read_length));
+      int position = pos_dist(rng);
+
+      out << "SOLEXA-1GA-2_2_FC" << fc_dist(rng) << ":" << lane_dist(rng) << ":" << tile_dist(rng) << ":"
+          << coord_dist(rng) << ":" << coord_dist(rng) << "\t";
+
+      out << (flag_dist(rng) * 16) << "\t" << chrom << "\t" << position << "\t" << 25 << "\t";
+
+      out << read_length << "M\t";
+      out << "*\t0\t0\t";
+
+      std::string sequence;
+      sequence.reserve(read_length);
+      for (int j = 0; j < read_length; ++j) {
+         sequence += bases[base_dist(rng)];
+      }
+      out << sequence << "\t";
+
+      for (int j = 0; j < read_length; ++j) {
+         out << static_cast<char>(qual_dist(rng));
+      }
+
+      int nm = mismatch_dist(rng) < 7 ? 0 : 1;
+      out << "\tNM:i:" << nm;
+      out << "\tX" << nm << ":i:1";
+      out << "\tMD:Z:" << read_length;
+      out << "\n";
+   }
+   out.close();
+}

--- a/benchmark/generate_sam_benchmark.cxx
+++ b/benchmark/generate_sam_benchmark.cxx
@@ -1,94 +1,18 @@
 #include <benchmark/benchmark.h>
 #include "generate_sam_benchmark.h"
-#include <fstream>
-#include <random>
-#include <vector>
-#include <string>
-#include <iostream>
 #include <cstdio> // For std::remove
 
-#ifndef BASE_SAM_READS
-#define BASE_SAM_READS 100
-#endif
-
-void GenerateSAMFile(const std::string& filename, int num_reads) {
-   std::mt19937 rng(42);
-   std::vector<std::pair<std::string, int>> chromosomes = {
-       {"chr1", 249250621}, {"chr2", 243199373}, {"chr3", 198022430},
-       {"chr4", 191154276}, {"chr5", 180915260}, {"chr6", 171115067},
-       {"chr7", 159138663}, {"chr8", 146364022}, {"chr9", 141213431},
-       {"chr10", 135534747}, {"chr11", 135006516}, {"chr12", 133851895},
-       {"chr13", 115169878}, {"chr14", 107349540}, {"chr15", 102531392},
-       {"chr16", 90354753}, {"chr17", 81195210}, {"chr18", 78077248},
-       {"chr19", 59128983}, {"chr20", 63025520}, {"chr21", 48129895},
-       {"chr22", 51304566}, {"chrM", 16571}, {"chrX", 155270560}
-   };
-
-   const char bases[4] = {'A', 'C', 'G', 'T'};
-   std::ofstream out(filename);
-   for (const auto& [chrom, length] : chromosomes) {
-       out << "@SQ\tSN:" << chrom << "\tLN:" << length << "\n";
-   }
-
-   std::uniform_int_distribution<> base_dist(0, 3);
-   std::uniform_int_distribution<> flag_dist(0, 1);
-   std::uniform_int_distribution<> chrom_dist(0, chromosomes.size() - 1);
-   std::uniform_int_distribution<> qual_dist(33, 73);
-   std::uniform_int_distribution<> fc_dist(10000, 99999);
-   std::uniform_int_distribution<> lane_dist(1, 8);
-   std::uniform_int_distribution<> tile_dist(1, 300);
-   std::uniform_int_distribution<> coord_dist(1, 1000);
-   std::uniform_int_distribution<> mismatch_dist(0, 9);
-
-   for (int i = 0; i < num_reads; ++i) {
-       auto [chrom, chrom_length] = chromosomes[chrom_dist(rng)];
-       int read_length = 36;
-       std::uniform_int_distribution<> pos_dist(1, std::max(1, chrom_length - read_length));
-       int position = pos_dist(rng);
-
-       out << "SOLEXA-1GA-2_2_FC" << fc_dist(rng)
-           << ":" << lane_dist(rng)
-           << ":" << tile_dist(rng)
-           << ":" << coord_dist(rng)
-           << ":" << coord_dist(rng) << "\t";
-
-       out << (flag_dist(rng) * 16) << "\t"
-           << chrom << "\t"
-           << position << "\t"
-           << 25 << "\t";
-
-       out << read_length << "M\t";
-       out << "*\t0\t0\t";
-
-       std::string sequence;
-       sequence.reserve(read_length);
-       for (int j = 0; j < read_length; ++j) {
-           sequence += bases[base_dist(rng)];
-       }
-       out << sequence << "\t";
-
-       for (int j = 0; j < read_length; ++j) {
-           out << static_cast<char>(qual_dist(rng));
-       }
-
-       int nm = mismatch_dist(rng) < 7 ? 0 : 1;
-       out << "\tNM:i:" << nm;
-       out << "\tX" << nm << ":i:1";
-       out << "\tMD:Z:" << read_length;
-       out << "\n";
-   }
-   out.close();
-}
-
-static void BM_GenerateSAM(benchmark::State& state) {
+static void BM_GenerateSAM(benchmark::State &state)
+{
    int num_reads = state.range(0);
    for (auto _ : state) {
-       GenerateSAMFile("benchmark_temp.sam", num_reads);
-       std::remove("benchmark_temp.sam");
+      GenerateSAMFile("benchmark_temp.sam", num_reads);
+      std::remove("benchmark_temp.sam");
    }
 
-   state.counters["reads_per_second"] = benchmark::Counter(
-       num_reads, benchmark::Counter::kIsRate);
-   state.counters["bytes_per_second"] = benchmark::Counter(
-       num_reads * 200, benchmark::Counter::kIsRate);
+   state.counters["reads_per_second"] = benchmark::Counter(num_reads, benchmark::Counter::kIsRate);
+   state.counters["bytes_per_second"] = benchmark::Counter(num_reads * 200, benchmark::Counter::kIsRate);
 }
+
+BENCHMARK(BM_GenerateSAM)->Range(100, 10000);
+BENCHMARK_MAIN();

--- a/src/ramcore/SamToNTuple.cxx
+++ b/src/ramcore/SamToNTuple.cxx
@@ -180,7 +180,9 @@ void samtoramntuple_split_by_chromosome(const char *datafile, const char *output
       t.join();
    }
 
-   auto write_chromosome_parallel = [&](const std::string &chr) {
+   std::mutex rnext_global_mutex;
+
+   auto write_chromosome_parallel = [&](const std::string &chr, std::mutex &rnext_mutex) {
       const auto &records = chromosome_records[chr];
 
       std::string filename = std::string(output_prefix) + "_" + chr + ".root";
@@ -221,7 +223,12 @@ void samtoramntuple_split_by_chromosome(const char *datafile, const char *output
                recordPtr->SetPOS(sam_record.pos);
                recordPtr->SetMAPQ(sam_record.mapq);
                recordPtr->SetCIGAR(sam_record.cigar.c_str());
-               recordPtr->SetREFNEXT(sam_record.rnext.c_str());
+
+               {
+                  std::lock_guard<std::mutex> lock(rnext_mutex);
+                  recordPtr->SetREFNEXT(sam_record.rnext.c_str());
+               }
+
                recordPtr->SetPNEXT(sam_record.pnext);
                recordPtr->SetTLEN(sam_record.tlen);
                recordPtr->SetSEQ(sam_record.seq.c_str());
@@ -262,7 +269,7 @@ void samtoramntuple_split_by_chromosome(const char *datafile, const char *output
       std::vector<std::thread> threads;
 
       for (int i = 0; i < num_threads && chr_idx < chr_names.size(); ++i, ++chr_idx) {
-         threads.emplace_back(write_chromosome_parallel, chr_names[chr_idx]);
+         threads.emplace_back(write_chromosome_parallel, chr_names[chr_idx], std::ref(rnext_global_mutex));
       }
 
       for (auto &t : threads) {

--- a/src/ramcore/SamToNTuple.cxx
+++ b/src/ramcore/SamToNTuple.cxx
@@ -219,7 +219,7 @@ void samtoramntuple_split_by_chromosome(const char *datafile, const char *output
                recordPtr->SetBit(quality_policy);
                recordPtr->SetQNAME(sam_record.qname.c_str());
                recordPtr->SetFLAG(sam_record.flag);
-               
+
                {
                   std::lock_guard<std::mutex> lock(record_mutex);
                   recordPtr->SetREFID(sam_record.rname.c_str());
@@ -277,4 +277,3 @@ void samtoramntuple_split_by_chromosome(const char *datafile, const char *output
       }
    }
 }
-

--- a/src/ramcore/SamToNTuple.cxx
+++ b/src/ramcore/SamToNTuple.cxx
@@ -47,7 +47,7 @@ void samtoramntuple(const char *datafile,
     writeOptions.SetMaxUnzippedPageSize(64000);
 
     auto writer = ROOT::RNTupleWriter::Append(std::move(model), "RAM", *rootFile, writeOptions);
-    auto defaultEntry = writer->GetModel().CreateEntry();
+    auto defaultEntry = writerGetModel().CreateEntry();
     auto recordPtr = defaultEntry->GetPtr<RAMNTupleRecord>("record");
     
     TList headers;
@@ -180,9 +180,9 @@ void samtoramntuple_split_by_chromosome(const char *datafile, const char *output
       t.join();
    }
 
-   std::mutex rnext_global_mutex;
+   std::mutex global_record_mutex;
 
-   auto write_chromosome_parallel = [&](const std::string &chr, std::mutex &rnext_mutex) {
+   auto write_chromosome_parallel = [&](const std::string &chr, std::mutex &record_mutex) {
       const auto &records = chromosome_records[chr];
 
       std::string filename = std::string(output_prefix) + "_" + chr + ".root";
@@ -219,16 +219,16 @@ void samtoramntuple_split_by_chromosome(const char *datafile, const char *output
                recordPtr->SetBit(quality_policy);
                recordPtr->SetQNAME(sam_record.qname.c_str());
                recordPtr->SetFLAG(sam_record.flag);
-               recordPtr->SetREFID(sam_record.rname.c_str());
-               recordPtr->SetPOS(sam_record.pos);
-               recordPtr->SetMAPQ(sam_record.mapq);
-               recordPtr->SetCIGAR(sam_record.cigar.c_str());
 
                {
-                  std::lock_guard<std::mutex> lock(rnext_mutex);
+                  std::lock_guard<std::mutex> lock(record_mutex);
+                  recordPtr->SetREFID(sam_record.rname.c_str());
                   recordPtr->SetREFNEXT(sam_record.rnext.c_str());
                }
 
+               recordPtr->SetPOS(sam_record.pos);
+               recordPtr->SetMAPQ(sam_record.mapq);
+               recordPtr->SetCIGAR(sam_record.cigar.c_str());
                recordPtr->SetPNEXT(sam_record.pnext);
                recordPtr->SetTLEN(sam_record.tlen);
                recordPtr->SetSEQ(sam_record.seq.c_str());
@@ -269,7 +269,8 @@ void samtoramntuple_split_by_chromosome(const char *datafile, const char *output
       std::vector<std::thread> threads;
 
       for (int i = 0; i < num_threads && chr_idx < chr_names.size(); ++i, ++chr_idx) {
-         threads.emplace_back(write_chromosome_parallel, chr_names[chr_idx], std::ref(rnext_global_mutex));
+
+         threads.emplace_back(write_chromosome_parallel, chr_names[chr_idx], std::ref(global_record_mutex));
       }
 
       for (auto &t : threads) {

--- a/src/ramcore/SamToNTuple.cxx
+++ b/src/ramcore/SamToNTuple.cxx
@@ -47,7 +47,7 @@ void samtoramntuple(const char *datafile,
     writeOptions.SetMaxUnzippedPageSize(64000);
 
     auto writer = ROOT::RNTupleWriter::Append(std::move(model), "RAM", *rootFile, writeOptions);
-    auto defaultEntry = writerGetModel().CreateEntry();
+    auto defaultEntry = writer->GetModel().CreateEntry();
     auto recordPtr = defaultEntry->GetPtr<RAMNTupleRecord>("record");
     
     TList headers;
@@ -219,7 +219,7 @@ void samtoramntuple_split_by_chromosome(const char *datafile, const char *output
                recordPtr->SetBit(quality_policy);
                recordPtr->SetQNAME(sam_record.qname.c_str());
                recordPtr->SetFLAG(sam_record.flag);
-
+               
                {
                   std::lock_guard<std::mutex> lock(record_mutex);
                   recordPtr->SetREFID(sam_record.rname.c_str());
@@ -269,7 +269,6 @@ void samtoramntuple_split_by_chromosome(const char *datafile, const char *output
       std::vector<std::thread> threads;
 
       for (int i = 0; i < num_threads && chr_idx < chr_names.size(); ++i, ++chr_idx) {
-
          threads.emplace_back(write_chromosome_parallel, chr_names[chr_idx], std::ref(global_record_mutex));
       }
 
@@ -278,3 +277,4 @@ void samtoramntuple_split_by_chromosome(const char *datafile, const char *output
       }
    }
 }
+

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -6,8 +6,6 @@ function(add_ramcore_test test_name)
         ${ARGN}
         LIBRARIES
             ramcore
-            sam_generator
-            benchmark::benchmark
             ROOT::Core
             ROOT::Tree
             ROOT::ROOTNTuple
@@ -15,6 +13,14 @@ function(add_ramcore_test test_name)
             gtest
             gtest_main
     )
+
+    if(RAMTOOLS_BUILD_BENCHMARKS)
+        target_link_libraries(${test_name} 
+            sam_generator
+            benchmark::benchmark
+        )
+    endif()
+
     target_include_directories(${test_name}
         PRIVATE
             $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/inc>

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -10,15 +10,14 @@ function(add_ramcore_test test_name)
             ROOT::Tree
             ROOT::ROOTNTuple
             ROOT::RIO
+            sam_generator  
             gtest
             gtest_main
     )
 
     if(RAMTOOLS_BUILD_BENCHMARKS)
-        target_link_libraries(${test_name} 
-            sam_generator
-            benchmark::benchmark
-        )
+    
+        target_link_libraries(${test_name} benchmark::benchmark)
     endif()
 
     target_include_directories(${test_name}


### PR DESCRIPTION
This PR adds Code coverage and clang-tidy workflow to the project.
The changes made are:-

1. Added Code Coverage Infrastructure
- Created .codecov.yml configuration with 85% coverage target for new code
- Added GitHub Actions coverage job that runs tests and generates coverage reports
- Added ENABLE_COVERAGE CMake option

2.  Added Static Code Analysis

- Created .github/workflows/clang-tidy-review-post.yml for automated code review
- Configured clang-tidy to post review comments on PRs (max 10 comments)
- Set up CI to fail on clang-tidy warnings

3. Fixed Build Dependencies

- Created generate_sam.cxx to separate SAM file generation from benchmark code
- Refactored sam_generator library to be available for tests without benchmark dependency
- Updated CMake to include benchmark directory when tests OR benchmarks are enabled
- Resolved circular dependency that prevented tests from building independently

4. CMake Improvements

- Added coverage build configuration with gcovr and lcov
- Created make coverage target for local coverage generation
- Fixed conditional compilation of test utilities