### PR TITLE
Fix: Index mapped reads at strategic positions

### DIFF
--- a/src/ramcore/SamToNTuple.cxx
+++ b/src/ramcore/SamToNTuple.cxx
@@ -54,7 +54,12 @@ void samtoramntuple(const char *datafile,
     headers.SetName("headers");
     
     ramcore::SamParser parser;
-    
+
+    // Indexing state
+    int64_t mapped_count = 0;
+    int32_t last_refid = -1;
+    int32_t last_indexed_pos = -10000;
+
     auto header_callback = [&headers](const std::string& tag, const std::string& content) {
         headers.Add(new TNamed(tag.c_str(), content.c_str()));
         
@@ -92,8 +97,20 @@ void samtoramntuple(const char *datafile,
 
        writer->Fill(*defaultEntry);
 
-       if (index && record_num % 1000 == 0) {
-          RAMNTupleRecord::GetIndex()->AddItem(recordPtr->GetREFID(), recordPtr->GetPOS() - 1, record_num);
+       // Only index mapped reads at strategic positions
+       if (index && !(sam_record.flag & 0x4) && recordPtr->GetREFID() >= 0) {
+          int32_t current_refid = recordPtr->GetREFID();
+          int32_t current_pos = recordPtr->GetPOS() - 1;
+
+          bool should_index =
+             (current_refid != last_refid) || (current_pos - last_indexed_pos >= 10000) || (mapped_count % 100 == 0);
+
+          if (should_index) {
+             RAMNTupleRecord::GetIndex()->AddItem(current_refid, current_pos, record_num);
+             last_refid = current_refid;
+             last_indexed_pos = current_pos;
+          }
+          mapped_count++;
        }
     };
 

--- a/src/ramcore/SamToNTuple.cxx
+++ b/src/ramcore/SamToNTuple.cxx
@@ -13,16 +13,22 @@
 #include <TFile.h>
 #include <TROOT.h>
 
-#include <map>
-#include <memory>
-#include <iostream>
-#include <fstream>
-#include <cstdio>
+#include <algorithm>
 #include <cstdint>
+#include <cstdio>
+#include <memory>
+#include <mutex>
+#include <string>
 #include <thread>
 #include <vector>
-#include <mutex>
-#include <algorithm>
+
+namespace {
+
+constexpr uint16_t kUnmapped = 0x4;
+constexpr int32_t kPositionInterval = 10000;
+constexpr int64_t kMappedInterval = 100;
+
+} // namespace
 
 void samtoramntuple(const char *datafile,
                     const char *treefile,
@@ -32,15 +38,15 @@ void samtoramntuple(const char *datafile,
 {
     TStopwatch stopwatch;
     stopwatch.Start();
-    
+
     auto rootFile = std::unique_ptr<TFile>(TFile::Open(treefile, "RECREATE"));
     if (!rootFile || !rootFile->IsOpen()) {
         printf("Failed to create RAM file %s\n", treefile);
         return;
     }
-    
+
     RAMNTupleRecord::InitializeRefs();
-    
+
     auto model = RAMNTupleRecord::MakeModel();
 
     ROOT::RNTupleWriteOptions writeOptions;
@@ -50,27 +56,26 @@ void samtoramntuple(const char *datafile,
     auto writer = ROOT::RNTupleWriter::Append(std::move(model), "RAM", *rootFile, writeOptions);
     auto defaultEntry = writer->GetModel().CreateEntry();
     auto recordPtr = defaultEntry->GetPtr<RAMNTupleRecord>("record");
-    
+
     TList headers;
     headers.SetName("headers");
-    
+
     ramcore::SamParser parser;
 
-    // Indexing state
     int64_t mapped_count = 0;
     int32_t last_refid = -1;
-    int32_t last_indexed_pos = -10000;
+    int32_t last_indexed_pos = -kPositionInterval;
 
     auto header_callback = [&headers](const std::string& tag, const std::string& content) {
         headers.Add(new TNamed(tag.c_str(), content.c_str()));
-        
+
         if (tag == "@SQ") {
             size_t sn_pos = content.find("SN:");
             if (sn_pos != std::string::npos) {
                 sn_pos += 3;
                 size_t tab_pos = content.find('\t', sn_pos);
-                std::string ref_name = content.substr(sn_pos, 
-                    tab_pos != std::string::npos ? tab_pos - sn_pos : std::string::npos);
+                std::string ref_name =
+                   content.substr(sn_pos, tab_pos != std::string::npos ? tab_pos - sn_pos : std::string::npos);
                 RAMNTupleRecord::GetRnameRefs()->GetRefId(ref_name.c_str());
             }
         }
@@ -98,15 +103,30 @@ void samtoramntuple(const char *datafile,
 
        writer->Fill(*defaultEntry);
 
-       // Only index mapped reads at strategic positions
-       if (index && !(sam_record.flag & 0x4) && recordPtr->GetREFID() >= 0) {
+       // Index building: create a sparse lookup table so region queries can jump
+       // directly to the relevant records instead of scanning from the beginning.
+       //
+       // Only mapped reads with a valid chromosome get indexed. The index maps
+       // (chromosome, position) → record_number.
+       //
+       // An entry is created when any of these triggers fire:
+       //   1. New chromosome — so queries on that chromosome have a starting point
+       //   2. Position gap >= 10kb — limits how far a query must scan forward
+       //   3. Every 100th mapped read — density guarantee for pileup regions
+       //      where reads are close together and the 10kb gap never triggers
+       //
+       // Duplicate entries at the same (chromosome, position) are skipped to ensure
+       // the index always points to the first record at any given position.
+       if (index && !(sam_record.flag & kUnmapped) && recordPtr->GetREFID() >= 0) {
           int32_t current_refid = recordPtr->GetREFID();
           int32_t current_pos = recordPtr->GetPOS() - 1;
 
-          bool should_index =
-             (current_refid != last_refid) || (current_pos - last_indexed_pos >= 10000) || (mapped_count % 100 == 0);
+          bool new_chrom = (current_refid != last_refid);
+          bool far_enough = (current_pos - last_indexed_pos >= kPositionInterval);
+          bool periodic = (mapped_count % kMappedInterval == 0);
+          bool duplicate = (!new_chrom && current_pos == last_indexed_pos);
 
-          if (should_index) {
+          if ((new_chrom || far_enough || periodic) && !duplicate) {
              RAMNTupleRecord::GetIndex()->AddItem(current_refid, current_pos, record_num);
              last_refid = current_refid;
              last_indexed_pos = current_pos;
@@ -119,31 +139,30 @@ void samtoramntuple(const char *datafile,
         printf("Failed to parse SAM file %s\n", datafile);
         return;
     }
-    
+
     writer.reset();
-    
+
     if (index) {
         RAMNTupleRecord::WriteIndex(*rootFile);
     }
     RAMNTupleRecord::WriteAllRefs(*rootFile);
-    
+
     headers.Write();
     rootFile->Close();
-    
+
     printf("\nRAM file created: %s\n", treefile);
     printf("Number of entries: %zu\n", parser.GetRecordsProcessed());
-    
+
     RAMNTupleRecord::GetRnameRefs()->Print();
     RAMNTupleRecord::GetRnextRefs()->Print();
-    
+
     if (index) {
         printf("\nIndex entries: %zu\n", RAMNTupleRecord::GetIndex()->Size());
     }
-    
-    printf("\nProcessed %zu SAM headers\n", 
-           parser.GetLinesProcessed() - parser.GetRecordsProcessed());
+
+    printf("\nProcessed %zu SAM headers\n", parser.GetLinesProcessed() - parser.GetRecordsProcessed());
     printf("Processed %zu SAM records\n\n", parser.GetRecordsProcessed());
-    
+
     stopwatch.Print();
 }
 

--- a/src/ramcore/SamToNTuple.cxx
+++ b/src/ramcore/SamToNTuple.cxx
@@ -18,6 +18,7 @@
 #include <iostream>
 #include <fstream>
 #include <cstdio>
+#include <cstdint>
 #include <thread>
 #include <vector>
 #include <mutex>

--- a/test/ramcoretests.cxx
+++ b/test/ramcoretests.cxx
@@ -176,3 +176,88 @@ TEST_F(ramcoreTest, RNTupleViewFlagFiltering)
 }
 
 } // namespace
+
+TEST_F(ramcoreTest, SmartIndexSkipsUnmappedReads)
+{
+   const char *customSam = "test_unmapped_index.sam";
+   const char *rntupleFile = "test_unmapped_index.root";
+
+   {
+      std::ofstream sam(customSam);
+      sam << "@HD\tVN:1.6\tSO:coordinate\n";
+      sam << "@SQ\tSN:chr1\tLN:100000\n";
+      sam << "mapped1\t0\tchr1\t1000\t60\t50M\t*\t0\t0\t" << std::string(50, 'A') << "\t*\n";
+      sam << "unmapped1\t4\t*\t0\t0\t*\t*\t0\t0\t" << std::string(50, 'A') << "\t*\n";
+      sam << "unmapped2\t4\t*\t0\t0\t*\t*\t0\t0\t" << std::string(50, 'A') << "\t*\n";
+      sam << "mapped2\t0\tchr1\t2000\t60\t50M\t*\t0\t0\t" << std::string(50, 'A') << "\t*\n";
+   }
+
+   samtoramntuple(customSam, rntupleFile, true, false, false, 505, 0);
+
+   Long64_t count = ramntupleview(rntupleFile, "chr1:900-2100", true, false, nullptr);
+   EXPECT_EQ(count, 2) << "Both mapped reads should be queryable";
+
+   Long64_t unmapped = ramntupleview(rntupleFile, "*:0-100", true, false, nullptr);
+   EXPECT_EQ(unmapped, 0) << "Unmapped reads should not appear in index queries";
+
+   std::remove(customSam);
+   std::remove(rntupleFile);
+}
+
+TEST_F(ramcoreTest, SmartIndexCreatesEntryAtChromosomeBoundary)
+{
+   const char *customSam = "test_chrom_boundary.sam";
+   const char *rntupleFile = "test_chrom_boundary.root";
+
+   {
+      std::ofstream sam(customSam);
+      sam << "@HD\tVN:1.6\tSO:coordinate\n";
+      sam << "@SQ\tSN:chr1\tLN:100000\n";
+      sam << "@SQ\tSN:chr2\tLN:100000\n";
+      for (int i = 0; i < 50; ++i)
+         sam << "chr1_r" << i << "\t0\tchr1\t" << (1000 + i * 100) << "\t60\t50M\t*\t0\t0\t" << std::string(50, 'A')
+             << "\t*\n";
+      for (int i = 0; i < 50; ++i)
+         sam << "chr2_r" << i << "\t0\tchr2\t" << (500 + i * 100) << "\t60\t50M\t*\t0\t0\t" << std::string(50, 'A')
+             << "\t*\n";
+   }
+
+   samtoramntuple(customSam, rntupleFile, true, false, false, 505, 0);
+
+   Long64_t chr1_hits = ramntupleview(rntupleFile, "chr1:1000-6000", true, false, nullptr);
+   EXPECT_GT(chr1_hits, 0) << "chr1 reads should be queryable";
+
+   Long64_t chr2_hits = ramntupleview(rntupleFile, "chr2:500-5500", true, false, nullptr);
+   EXPECT_GT(chr2_hits, 0) << "chr2 reads should be immediately queryable at boundary";
+
+   std::remove(customSam);
+   std::remove(rntupleFile);
+}
+
+TEST_F(ramcoreTest, SmartIndexRespectsPositionInterval)
+{
+   const char *customSam = "test_pos_interval.sam";
+   const char *rntupleFile = "test_pos_interval.root";
+
+   {
+      std::ofstream sam(customSam);
+      sam << "@HD\tVN:1.6\tSO:coordinate\n";
+      sam << "@SQ\tSN:chr1\tLN:1000000\n";
+      // Cluster of 200 reads at position 1000 (same position, should not generate 200 index entries)
+      for (int i = 0; i < 200; ++i)
+         sam << "cluster_r" << i << "\t0\tchr1\t1000\t60\t50M\t*\t0\t0\t" << std::string(50, 'A') << "\t*\n";
+      // Read far away at 50000 (>10kb gap, should trigger position interval index)
+      sam << "far_read\t0\tchr1\t50000\t60\t50M\t*\t0\t0\t" << std::string(50, 'A') << "\t*\n";
+   }
+
+   samtoramntuple(customSam, rntupleFile, true, false, false, 505, 0);
+
+   Long64_t cluster = ramntupleview(rntupleFile, "chr1:900-1100", true, false, nullptr);
+   EXPECT_EQ(cluster, 200);
+
+   Long64_t far = ramntupleview(rntupleFile, "chr1:49900-50100", true, false, nullptr);
+   EXPECT_EQ(far, 1) << "Distant read should be indexed via position interval";
+
+   std::remove(customSam);
+   std::remove(rntupleFile);
+}


### PR DESCRIPTION
- Index first read of each chromosome
- Index every 10000 bases
- Index every 100 mapped reads as fallback
- Skip unmapped reads