### PR TITLE
[clang-tidy] Add gtest include path

### DIFF
--- a/.github/workflows/clang-tidy-review.yml
+++ b/.github/workflows/clang-tidy-review.yml
@@ -49,7 +49,10 @@ jobs:
           apt_packages: cmake,libxml2,libxml2-dev,libtinfo-dev,zlib1g-dev,libzstd-dev,libvdt-dev,libtbb-dev
           split_workflow: true
           config_file: .clang-tidy
-          clang_tidy_args: '--extra-arg=-I${{ github.workspace }}/inc --extra-arg=-I/opt/root/include'
+          clang_tidy_args: >
+            --extra-arg=-I${{ github.workspace }}/inc
+            --extra-arg=-I/opt/root/include
+            --extra-arg=-I${{ github.workspace }}/build/test/googletest-prefix/src/googletest/googletest/include
           cmake_command: >
             bash -x -c '
             source /opt/root/bin/thisroot.sh &&


### PR DESCRIPTION
This PR add gtest include path to clang-tidy workflow.