### PR TITLE
[fix] return SAM-compatible 1-based coordinates in RAMRecord getters

### DIFF
--- a/inc/ttree/RAMRecord.h
+++ b/inc/ttree/RAMRecord.h
@@ -178,11 +178,11 @@ public:
    void SetQNAME(const char *qname) { v_qname = qname; }
    void SetFLAG(UShort_t f) { v_flag = f; }
    void SetREFID(const char *rname);
-   void SetPOS(Int_t pos) { v_pos = pos - 1; }
+   void SetPOS(Int_t pos) { v_pos = pos - 1; } // SAM is 1-based, we are 0-based
    void SetMAPQ(UChar_t mapq) { v_mapq = mapq; }
    void SetCIGAR(const char *cigar);
    void SetREFNEXT(const char *rnext);
-   void SetPNEXT(Int_t pnext) { v_pnext = pnext - 1; }
+   void SetPNEXT(Int_t pnext) { v_pnext = pnext - 1; } // SAM is 1-based, we are 0-based
    void SetTLEN(Int_t tlen) { v_tlen = tlen; }
    void SetSEQ(const char *seq);
    void SetQUAL(const char *qual);
@@ -193,7 +193,7 @@ public:
    UInt_t GetFLAG() const { return v_flag; }
    const char *GetRNAME() const;
    Int_t GetREFID() const { return v_refid; }
-   Int_t GetPOS() const { return v_pos; }
+   Int_t GetPOS() const { return v_pos + 1; } // Convert back to 1-based for SAM
    UInt_t GetMAPQ() const { return v_mapq; }
    Int_t GetNCIGAROP() { return v_ncigar_op; }
    Int_t GetCIGAROPLEN(Int_t idx);
@@ -201,7 +201,7 @@ public:
    const char *GetCIGAR() const;
    const char *GetRNEXT() const;
    Int_t GetREFNEXT() const { return v_refnext; }
-   Int_t GetPNEXT() const { return v_pnext; }
+   Int_t GetPNEXT() const { return v_pnext + 1; } // Convert back to 1-based for SAM
    Int_t GetTLEN() const { return v_tlen; }
    Int_t GetSEQLEN() const { return v_lseq; }
    const char *GetSEQ() const;
@@ -643,8 +643,8 @@ inline void RAMRecord::Print(Option_t *) const
 {
    // Print a single record, in SAM format.
 
-   std::cout << GetQNAME() << "\t" << GetFLAG() << "\t" << GetRNAME() << "\t" << GetPOS() + 1 << "\t" << GetMAPQ()
-             << "\t" << GetCIGAR() << "\t" << GetRNEXT() << "\t" << GetPNEXT() + 1 << "\t" << GetTLEN() << "\t"
+   std::cout << GetQNAME() << "\t" << GetFLAG() << "\t" << GetRNAME() << "\t" << GetPOS() << "\t" << GetMAPQ()
+             << "\t" << GetCIGAR() << "\t" << GetRNEXT() << "\t" << GetPNEXT() << "\t" << GetTLEN() << "\t"
              << GetSEQ() << "\t" << GetQUAL();
    for (int i = 0; i < GetNOPT(); i++)
       std::cout << "\t" << GetOPT(i);

--- a/src/ramcore/SamToTTree.cxx
+++ b/src/ramcore/SamToTTree.cxx
@@ -73,7 +73,8 @@ void samtoram(const char *datafile,
         tree->Fill();
         
         if (index && record_num % 1000 == 0) {
-            RAMRecord::GetIndex()->AddItem(r->GetREFID(), r->GetPOS(), record_num);
+            // GetPOS() returns 1-based SAM coordinate, convert to internal 0-based
+            RAMRecord::GetIndex()->AddItem(r->GetREFID(), r->GetPOS() - 1, record_num);
         }
     };
     

--- a/tools/ramview.cxx
+++ b/tools/ramview.cxx
@@ -76,7 +76,8 @@ Long64_t ramview(const char *file, const char *query, bool cache = true, bool pe
 
    for (; start_entry < t->GetEntries(); start_entry++) {
       t->GetEntry(start_entry);
-      if (r->GetPOS() + r->GetSEQLEN() > range_start) {
+      // GetPOS() returns 1-based SAM coordinate, convert to internal 0-based
+      if (r->GetPOS() - 1 + r->GetSEQLEN() > range_start) {
 
          break;
       }
@@ -90,7 +91,8 @@ Long64_t ramview(const char *file, const char *query, bool cache = true, bool pe
 
    for (j = start_entry; j < t->GetEntries(); j++) {
       t->GetEntry(j);
-      if (r->GetPOS() >= range_end) {
+      // GetPOS() returns 1-based SAM coordinate, convert to internal 0-based
+      if (r->GetPOS() - 1 >= range_end) {
          break;
       }
       count++;

--- a/tools/ramview_no_index.cxx
+++ b/tools/ramview_no_index.cxx
@@ -87,7 +87,8 @@ void ramview_no_index(const char *file, const char *query, bool cache = false, b
          if (!rname.EqualTo(r->GetRNAME())) {
             break;
          } else {
-            if (r->GetPOS() + r->GetSEQLEN() > rangeStart) {
+            // GetPOS() returns 1-based SAM coordinate, convert to internal 0-based
+            if (r->GetPOS() - 1 + r->GetSEQLEN() > rangeStart) {
                // Register first valid position for printing
                posStart = i;
                break;
@@ -110,7 +111,8 @@ void ramview_no_index(const char *file, const char *query, bool cache = false, b
                break;
             } else {
                // Within the region
-               if (r->GetPOS() <= rangeEnd) {
+               // GetPOS() returns 1-based SAM coordinate, convert to internal 0-based
+               if (r->GetPOS() - 1 <= rangeEnd) {
                   r->Print();
                } else {
                   break;


### PR DESCRIPTION
SAM files use 1-based coordinates , but we use 0 based , So in setters of `pos` and `pnext` we subtract 1 to do the conversion . We expose this variables via the `GETPOS()` and `GETPNEXT()` API's which returns these variables without conversion in `RAMRecord` ( TTree based implementation ) whereas in `RAMNTupleRecord` we convert them to 1 based in getters. This PR makes the API's inconsistent.

do -1 if we need the 0 based coordinates ( done for GETPOS and GETPNEXT of RAMNTupleRecord so we follow that)
Adds comments where we do -1 to get the 0-based coordinates for clarity.

Should not effect current behaviour since i changed all the usage of these getters , but i ran the tools before and after to test the changes :

`output.root` & `output2.root` is created by develop branch  build and `output_n.root` & `output2_n.root` by fix branch

<img width="1589" height="182" alt="image" src="https://github.com/user-attachments/assets/69e4f288-b439-40e8-b6b2-5fcddc1e41ae" />

Region queries returned same results:

<img width="1296" height="490" alt="image" src="https://github.com/user-attachments/assets/0bf600cc-f47f-4339-8eb0-ecf7af505503" />

<img width="1541" height="368" alt="image" src="https://github.com/user-attachments/assets/e1ef460d-b5ca-4d91-b179-013a8e21d10b" />


