### PR TITLE
Add ramsort tool: coordinate and name sort for RAM (RNTuple) files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,6 +43,7 @@ ROOT_STANDARD_LIBRARY_PACKAGE(ramcore
         inc/ramcore/SamToTTree.h
         inc/ramcore/SamToNTuple.h
         inc/ramcore/RAMNTupleView.h
+        inc/ramcore/RAMSort.h
     SOURCES
         src/ttree/RAMRecord.cxx
         src/rntuple/RAMNTupleRecord.cxx
@@ -50,6 +51,7 @@ ROOT_STANDARD_LIBRARY_PACKAGE(ramcore
         src/ramcore/SamToTTree.cxx
         src/ramcore/SamToNTuple.cxx
         src/ramcore/RAMNTupleView.cxx
+        src/ramcore/RAMSort.cxx
     LINKDEF
         inc/ttree/LinkDef.h
     DEPENDENCIES

--- a/inc/ramcore/RAMSort.h
+++ b/inc/ramcore/RAMSort.h
@@ -1,0 +1,11 @@
+#ifndef RAMCORE_RAMSORT_H
+#define RAMCORE_RAMSORT_H
+
+/// Sort a RAM (RNTuple) file by coordinate (refid, pos) or by QNAME.
+/// \param inputFile   Path to input .root RAM file
+/// \param outputFile  Path to output .root RAM file
+/// \param byName      If true, sort by QNAME; otherwise sort by (refid, pos)
+/// \return 0 on success, 1 on error
+int ramsortntuple(const char *inputFile, const char *outputFile, bool byName = false);
+
+#endif // RAMCORE_RAMSORT_H

--- a/src/ramcore/RAMSort.cxx
+++ b/src/ramcore/RAMSort.cxx
@@ -3,15 +3,19 @@
 
 #include <ROOT/RNTupleModel.hxx>
 #include <ROOT/RNTupleReader.hxx>
-#include <ROOT/RNTupleWriter.hxx>
-#include <ROOT/RNTupleWriteOptions.hxx>
 #include <ROOT/RNTupleView.hxx>
+#include <ROOT/RNTupleWriteOptions.hxx>
+#include <ROOT/RNTupleWriter.hxx>
 #include <TFile.h>
 
 #include <algorithm>
+#include <cstdint>
+#include <exception>
 #include <iostream>
+#include <memory>
 #include <numeric>
 #include <string>
+#include <utility>
 #include <vector>
 
 int ramsortntuple(const char *inputFile, const char *outputFile, bool byName)
@@ -37,7 +41,7 @@ int ramsortntuple(const char *inputFile, const char *outputFile, bool byName)
    auto viewQname = reader->GetView<std::string>("record.qname");
 
    std::vector<uint64_t> order(nEntries);
-   std::iota(order.begin(), order.end(), 0);
+   std::iota(order.begin(), order.end(), 0ULL);
 
    std::cout << "Sorting " << nEntries << " records";
    if (byName)
@@ -52,7 +56,8 @@ int ramsortntuple(const char *inputFile, const char *outputFile, bool byName)
       std::stable_sort(order.begin(), order.end(),
                        [&](uint64_t a, uint64_t b) { return qnames[a] < qnames[b]; });
    } else {
-      std::vector<int32_t> refids(nEntries), positions(nEntries);
+      std::vector<int32_t> refids(nEntries);
+      std::vector<int32_t> positions(nEntries);
       for (uint64_t i = 0; i < nEntries; ++i) {
          refids[i]    = viewRefId(i);
          positions[i] = viewPos(i);
@@ -75,7 +80,7 @@ int ramsortntuple(const char *inputFile, const char *outputFile, bool byName)
    RAMNTupleRecord::InitializeRefs();
    auto model = RAMNTupleRecord::MakeModel();
    ROOT::RNTupleWriteOptions writeOptions;
-   writeOptions.SetCompression(505);
+   writeOptions.SetCompression(/*val=*/505);
    auto writer    = ROOT::RNTupleWriter::Append(std::move(model), "RAM", *rootFile, writeOptions);
    auto entry     = writer->GetModel().CreateEntry();
    auto recordPtr = entry->GetPtr<RAMNTupleRecord>("record");

--- a/src/ramcore/RAMSort.cxx
+++ b/src/ramcore/RAMSort.cxx
@@ -37,7 +37,7 @@ int ramsortntuple(const char *inputFile, const char *outputFile, bool byName)
    }
 
    auto viewRefId = reader->GetView<int32_t>("record.refid");
-   auto viewPos   = reader->GetView<int32_t>("record.pos");
+   auto viewPos = reader->GetView<int32_t>("record.pos");
    auto viewQname = reader->GetView<std::string>("record.qname");
 
    std::vector<uint64_t> order(nEntries);
@@ -53,13 +53,12 @@ int ramsortntuple(const char *inputFile, const char *outputFile, bool byName)
       std::vector<std::string> qnames(nEntries);
       for (uint64_t i = 0; i < nEntries; ++i)
          qnames[i] = viewQname(i);
-      std::stable_sort(order.begin(), order.end(),
-                       [&](uint64_t a, uint64_t b) { return qnames[a] < qnames[b]; });
+      std::stable_sort(order.begin(), order.end(), [&](uint64_t a, uint64_t b) { return qnames[a] < qnames[b]; });
    } else {
       std::vector<int32_t> refids(nEntries);
       std::vector<int32_t> positions(nEntries);
       for (uint64_t i = 0; i < nEntries; ++i) {
-         refids[i]    = viewRefId(i);
+         refids[i] = viewRefId(i);
          positions[i] = viewPos(i);
       }
       std::stable_sort(order.begin(), order.end(), [&](uint64_t a, uint64_t b) {
@@ -81,8 +80,8 @@ int ramsortntuple(const char *inputFile, const char *outputFile, bool byName)
    auto model = RAMNTupleRecord::MakeModel();
    ROOT::RNTupleWriteOptions writeOptions;
    writeOptions.SetCompression(/*val=*/505);
-   auto writer    = ROOT::RNTupleWriter::Append(std::move(model), "RAM", *rootFile, writeOptions);
-   auto entry     = writer->GetModel().CreateEntry();
+   auto writer = ROOT::RNTupleWriter::Append(std::move(model), "RAM", *rootFile, writeOptions);
+   auto entry = writer->GetModel().CreateEntry();
    auto recordPtr = entry->GetPtr<RAMNTupleRecord>("record");
 
    for (uint64_t idx : order) {

--- a/src/ramcore/RAMSort.cxx
+++ b/src/ramcore/RAMSort.cxx
@@ -1,0 +1,93 @@
+#include "ramcore/RAMSort.h"
+#include "rntuple/RAMNTupleRecord.h"
+
+#include <ROOT/RNTupleModel.hxx>
+#include <ROOT/RNTupleReader.hxx>
+#include <ROOT/RNTupleWriter.hxx>
+#include <ROOT/RNTupleWriteOptions.hxx>
+#include <ROOT/RNTupleView.hxx>
+#include <TFile.h>
+
+#include <algorithm>
+#include <iostream>
+#include <numeric>
+#include <string>
+#include <vector>
+
+int ramsortntuple(const char *inputFile, const char *outputFile, bool byName)
+{
+   RAMNTupleRecord::ReadAllRefs(inputFile);
+
+   std::unique_ptr<ROOT::RNTupleReader> reader;
+   try {
+      reader = ROOT::RNTupleReader::Open("RAM", inputFile);
+   } catch (const std::exception &e) {
+      std::cerr << "Error opening input: " << e.what() << "\n";
+      return 1;
+   }
+
+   const uint64_t nEntries = reader->GetNEntries();
+   if (nEntries == 0) {
+      std::cerr << "Input file has no entries.\n";
+      return 1;
+   }
+
+   auto viewRefId = reader->GetView<int32_t>("record.refid");
+   auto viewPos   = reader->GetView<int32_t>("record.pos");
+   auto viewQname = reader->GetView<std::string>("record.qname");
+
+   std::vector<uint64_t> order(nEntries);
+   std::iota(order.begin(), order.end(), 0);
+
+   std::cout << "Sorting " << nEntries << " records";
+   if (byName)
+      std::cout << " by QNAME...\n";
+   else
+      std::cout << " by coordinate (refid, pos)...\n";
+
+   if (byName) {
+      std::vector<std::string> qnames(nEntries);
+      for (uint64_t i = 0; i < nEntries; ++i)
+         qnames[i] = viewQname(i);
+      std::stable_sort(order.begin(), order.end(),
+                       [&](uint64_t a, uint64_t b) { return qnames[a] < qnames[b]; });
+   } else {
+      std::vector<int32_t> refids(nEntries), positions(nEntries);
+      for (uint64_t i = 0; i < nEntries; ++i) {
+         refids[i]    = viewRefId(i);
+         positions[i] = viewPos(i);
+      }
+      std::stable_sort(order.begin(), order.end(), [&](uint64_t a, uint64_t b) {
+         if (refids[a] != refids[b])
+            return refids[a] < refids[b];
+         return positions[a] < positions[b];
+      });
+   }
+
+   auto viewRecord = reader->GetView<RAMNTupleRecord>("record");
+
+   auto rootFile = std::unique_ptr<TFile>(TFile::Open(outputFile, "RECREATE"));
+   if (!rootFile || !rootFile->IsOpen()) {
+      std::cerr << "Error: could not create output file " << outputFile << "\n";
+      return 1;
+   }
+
+   RAMNTupleRecord::InitializeRefs();
+   auto model = RAMNTupleRecord::MakeModel();
+   ROOT::RNTupleWriteOptions writeOptions;
+   writeOptions.SetCompression(505);
+   auto writer    = ROOT::RNTupleWriter::Append(std::move(model), "RAM", *rootFile, writeOptions);
+   auto entry     = writer->GetModel().CreateEntry();
+   auto recordPtr = entry->GetPtr<RAMNTupleRecord>("record");
+
+   for (uint64_t idx : order) {
+      *recordPtr = viewRecord(idx);
+      writer->Fill(*entry);
+   }
+
+   RAMNTupleRecord::WriteAllRefs(*rootFile);
+   RAMNTupleRecord::WriteIndex(*rootFile);
+
+   std::cout << "Sorted output written to " << outputFile << "\n";
+   return 0;
+}

--- a/src/ramcore/RAMSort.cxx
+++ b/src/ramcore/RAMSort.cxx
@@ -37,7 +37,7 @@ int ramsortntuple(const char *inputFile, const char *outputFile, bool byName)
    }
 
    auto viewRefId = reader->GetView<int32_t>("record.refid");
-   auto viewPos = reader->GetView<int32_t>("record.pos");
+   auto viewPos   = reader->GetView<int32_t>("record.pos");
    auto viewQname = reader->GetView<std::string>("record.qname");
 
    std::vector<uint64_t> order(nEntries);
@@ -53,12 +53,13 @@ int ramsortntuple(const char *inputFile, const char *outputFile, bool byName)
       std::vector<std::string> qnames(nEntries);
       for (uint64_t i = 0; i < nEntries; ++i)
          qnames[i] = viewQname(i);
-      std::stable_sort(order.begin(), order.end(), [&](uint64_t a, uint64_t b) { return qnames[a] < qnames[b]; });
+      std::stable_sort(order.begin(), order.end(),
+                       [&](uint64_t a, uint64_t b) { return qnames[a] < qnames[b]; });
    } else {
       std::vector<int32_t> refids(nEntries);
       std::vector<int32_t> positions(nEntries);
       for (uint64_t i = 0; i < nEntries; ++i) {
-         refids[i] = viewRefId(i);
+         refids[i]    = viewRefId(i);
          positions[i] = viewPos(i);
       }
       std::stable_sort(order.begin(), order.end(), [&](uint64_t a, uint64_t b) {
@@ -70,7 +71,7 @@ int ramsortntuple(const char *inputFile, const char *outputFile, bool byName)
 
    auto viewRecord = reader->GetView<RAMNTupleRecord>("record");
 
-   auto rootFile = std::unique_ptr<TFile>(TFile::Open(outputFile, "RECREATE"));
+   auto rootFile = std::unique_ptr<TFile>(TFile::Open(outputFile, /*option=*/"RECREATE"));
    if (!rootFile || !rootFile->IsOpen()) {
       std::cerr << "Error: could not create output file " << outputFile << "\n";
       return 1;
@@ -80,8 +81,8 @@ int ramsortntuple(const char *inputFile, const char *outputFile, bool byName)
    auto model = RAMNTupleRecord::MakeModel();
    ROOT::RNTupleWriteOptions writeOptions;
    writeOptions.SetCompression(/*val=*/505);
-   auto writer = ROOT::RNTupleWriter::Append(std::move(model), "RAM", *rootFile, writeOptions);
-   auto entry = writer->GetModel().CreateEntry();
+   auto writer    = ROOT::RNTupleWriter::Append(std::move(model), "RAM", *rootFile, writeOptions);
+   auto entry     = writer->GetModel().CreateEntry();
    auto recordPtr = entry->GetPtr<RAMNTupleRecord>("record");
 
    for (uint64_t idx : order) {

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -36,3 +36,4 @@ install(TARGETS ramcoretests chromosome_split_test
     RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
 )
 
+add_ramcore_test(ramsorttests ramsorttests.cxx)

--- a/test/ramsorttests.cxx
+++ b/test/ramsorttests.cxx
@@ -13,9 +13,9 @@ namespace {
 class RAMSortTest : public ::testing::Test {
 protected:
    static constexpr int kNumReads = 200;
-   const char *kSamFile      = "sort_test.sam";
+   const char *kSamFile = "sort_test.sam";
    const char *kUnsortedFile = "sort_test_unsorted.root";
-   const char *kSortedFile   = "sort_test_sorted.root";
+   const char *kSortedFile = "sort_test_sorted.root";
    const char *kNameSortFile = "sort_test_namesort.root";
 
    void SetUp() override
@@ -39,9 +39,9 @@ protected:
 TEST_F(RAMSortTest, EntryCountPreserved)
 {
    ASSERT_EQ(ramsortntuple(kUnsortedFile, kSortedFile), 0);
-   auto readerIn  = ROOT::RNTupleReader::Open("RAM", kUnsortedFile);
+   auto readerIn = ROOT::RNTupleReader::Open("RAM", kUnsortedFile);
    auto readerOut = ROOT::RNTupleReader::Open("RAM", kSortedFile);
-   ASSERT_NE(readerIn,  nullptr);
+   ASSERT_NE(readerIn, nullptr);
    ASSERT_NE(readerOut, nullptr);
    EXPECT_EQ(readerIn->GetNEntries(), readerOut->GetNEntries());
 }
@@ -49,28 +49,28 @@ TEST_F(RAMSortTest, EntryCountPreserved)
 TEST_F(RAMSortTest, CoordinateSortOrder)
 {
    ASSERT_EQ(ramsortntuple(kUnsortedFile, kSortedFile), 0);
-   auto reader    = ROOT::RNTupleReader::Open("RAM", kSortedFile);
+   auto reader = ROOT::RNTupleReader::Open("RAM", kSortedFile);
    ASSERT_NE(reader, nullptr);
    auto viewRefId = reader->GetView<int32_t>("record.refid");
-   auto viewPos   = reader->GetView<int32_t>("record.pos");
+   auto viewPos = reader->GetView<int32_t>("record.pos");
    int32_t prevRefId = -1, prevPos = -1;
    for (uint64_t i = 0; i < reader->GetNEntries(); ++i) {
       int32_t refid = viewRefId(i);
-      int32_t pos   = viewPos(i);
+      int32_t pos = viewPos(i);
       if (refid == prevRefId) {
          EXPECT_GE(pos, prevPos) << "pos out of order at entry " << i;
       } else {
          EXPECT_GE(refid, prevRefId) << "refid out of order at entry " << i;
       }
       prevRefId = refid;
-      prevPos   = pos;
+      prevPos = pos;
    }
 }
 
 TEST_F(RAMSortTest, NameSortOrder)
 {
    ASSERT_EQ(ramsortntuple(kUnsortedFile, kNameSortFile, true), 0);
-   auto reader    = ROOT::RNTupleReader::Open("RAM", kNameSortFile);
+   auto reader = ROOT::RNTupleReader::Open("RAM", kNameSortFile);
    ASSERT_NE(reader, nullptr);
    auto viewQname = reader->GetView<std::string>("record.qname");
    std::string prev = "";
@@ -93,11 +93,11 @@ TEST_F(RAMSortTest, IdempotentSort)
    EXPECT_EQ(r1->GetNEntries(), r2->GetNEntries());
    auto v1refid = r1->GetView<int32_t>("record.refid");
    auto v2refid = r2->GetView<int32_t>("record.refid");
-   auto v1pos   = r1->GetView<int32_t>("record.pos");
-   auto v2pos   = r2->GetView<int32_t>("record.pos");
+   auto v1pos = r1->GetView<int32_t>("record.pos");
+   auto v2pos = r2->GetView<int32_t>("record.pos");
    for (uint64_t i = 0; i < r1->GetNEntries(); ++i) {
       EXPECT_EQ(v1refid(i), v2refid(i));
-      EXPECT_EQ(v1pos(i),   v2pos(i));
+      EXPECT_EQ(v1pos(i), v2pos(i));
    }
    std::remove(doubleSorted);
 }
@@ -107,7 +107,6 @@ TEST(RAMSortEdgeCases, MissingInputFileReturnsError)
    int ret = ramsortntuple("nonexistent.root", "/tmp/out.root");
    EXPECT_NE(ret, 0);
 }
-
 
 /// ramsortntuple on an empty file must return 1.
 TEST(RAMSortEdgeCases, EmptyFileReturnsError)

--- a/test/ramsorttests.cxx
+++ b/test/ramsorttests.cxx
@@ -2,6 +2,7 @@
 #include <ROOT/RNTupleReader.hxx>
 #include <ROOT/RNTupleView.hxx>
 #include <cstdio>
+#include <fstream>
 
 #include "../benchmark/generate_sam_benchmark.h"
 #include "ramcore/RAMSort.h"
@@ -105,6 +106,38 @@ TEST(RAMSortEdgeCases, MissingInputFileReturnsError)
 {
    int ret = ramsortntuple("nonexistent.root", "/tmp/out.root");
    EXPECT_NE(ret, 0);
+}
+
+
+/// ramsortntuple on an empty file must return 1.
+TEST(RAMSortEdgeCases, EmptyFileReturnsError)
+{
+   // Create an empty RAM file with zero entries
+   const char *emptySam = "empty_sort.sam";
+   const char *emptyRoot = "empty_sort.root";
+   {
+      std::ofstream f(emptySam);
+      f << "@HD\tVN:1.6\n";
+   }
+   samtoramntuple(emptySam, emptyRoot, false, false, false, 505, 0);
+   int ret = ramsortntuple(emptyRoot, "empty_sort_out.root");
+   EXPECT_NE(ret, 0);
+   std::remove(emptySam);
+   std::remove(emptyRoot);
+   std::remove("empty_sort_out.root");
+}
+
+/// ramsortntuple with invalid output path must return 1.
+TEST(RAMSortEdgeCases, InvalidOutputPathReturnsError)
+{
+   const char *samFile = "sort_edge.sam";
+   const char *rootFile = "sort_edge.root";
+   GenerateSAMFile(samFile, 10);
+   samtoramntuple(samFile, rootFile, false, false, false, 505, 0);
+   int ret = ramsortntuple(rootFile, "/nonexistent/path/out.root");
+   EXPECT_NE(ret, 0);
+   std::remove(samFile);
+   std::remove(rootFile);
 }
 
 } // namespace

--- a/test/ramsorttests.cxx
+++ b/test/ramsorttests.cxx
@@ -1,0 +1,110 @@
+#include <gtest/gtest.h>
+#include <ROOT/RNTupleReader.hxx>
+#include <ROOT/RNTupleView.hxx>
+#include <cstdio>
+
+#include "../benchmark/generate_sam_benchmark.h"
+#include "ramcore/RAMSort.h"
+#include "ramcore/SamToNTuple.h"
+
+namespace {
+
+class RAMSortTest : public ::testing::Test {
+protected:
+   static constexpr int kNumReads = 200;
+   const char *kSamFile      = "sort_test.sam";
+   const char *kUnsortedFile = "sort_test_unsorted.root";
+   const char *kSortedFile   = "sort_test_sorted.root";
+   const char *kNameSortFile = "sort_test_namesort.root";
+
+   void SetUp() override
+   {
+      GenerateSAMFile(kSamFile, kNumReads);
+      std::remove(kUnsortedFile);
+      std::remove(kSortedFile);
+      std::remove(kNameSortFile);
+      samtoramntuple(kSamFile, kUnsortedFile, true, true, true, 505, 0);
+   }
+
+   void TearDown() override
+   {
+      std::remove(kSamFile);
+      std::remove(kUnsortedFile);
+      std::remove(kSortedFile);
+      std::remove(kNameSortFile);
+   }
+};
+
+TEST_F(RAMSortTest, EntryCountPreserved)
+{
+   ASSERT_EQ(ramsortntuple(kUnsortedFile, kSortedFile), 0);
+   auto readerIn  = ROOT::RNTupleReader::Open("RAM", kUnsortedFile);
+   auto readerOut = ROOT::RNTupleReader::Open("RAM", kSortedFile);
+   ASSERT_NE(readerIn,  nullptr);
+   ASSERT_NE(readerOut, nullptr);
+   EXPECT_EQ(readerIn->GetNEntries(), readerOut->GetNEntries());
+}
+
+TEST_F(RAMSortTest, CoordinateSortOrder)
+{
+   ASSERT_EQ(ramsortntuple(kUnsortedFile, kSortedFile), 0);
+   auto reader    = ROOT::RNTupleReader::Open("RAM", kSortedFile);
+   ASSERT_NE(reader, nullptr);
+   auto viewRefId = reader->GetView<int32_t>("record.refid");
+   auto viewPos   = reader->GetView<int32_t>("record.pos");
+   int32_t prevRefId = -1, prevPos = -1;
+   for (uint64_t i = 0; i < reader->GetNEntries(); ++i) {
+      int32_t refid = viewRefId(i);
+      int32_t pos   = viewPos(i);
+      if (refid == prevRefId) {
+         EXPECT_GE(pos, prevPos) << "pos out of order at entry " << i;
+      } else {
+         EXPECT_GE(refid, prevRefId) << "refid out of order at entry " << i;
+      }
+      prevRefId = refid;
+      prevPos   = pos;
+   }
+}
+
+TEST_F(RAMSortTest, NameSortOrder)
+{
+   ASSERT_EQ(ramsortntuple(kUnsortedFile, kNameSortFile, true), 0);
+   auto reader    = ROOT::RNTupleReader::Open("RAM", kNameSortFile);
+   ASSERT_NE(reader, nullptr);
+   auto viewQname = reader->GetView<std::string>("record.qname");
+   std::string prev = "";
+   for (uint64_t i = 0; i < reader->GetNEntries(); ++i) {
+      std::string qname = viewQname(i);
+      EXPECT_GE(qname, prev) << "qname out of order at entry " << i;
+      prev = qname;
+   }
+}
+
+TEST_F(RAMSortTest, IdempotentSort)
+{
+   ASSERT_EQ(ramsortntuple(kUnsortedFile, kSortedFile), 0);
+   const char *doubleSorted = "sort_test_double.root";
+   ASSERT_EQ(ramsortntuple(kSortedFile, doubleSorted), 0);
+   auto r1 = ROOT::RNTupleReader::Open("RAM", kSortedFile);
+   auto r2 = ROOT::RNTupleReader::Open("RAM", doubleSorted);
+   ASSERT_NE(r1, nullptr);
+   ASSERT_NE(r2, nullptr);
+   EXPECT_EQ(r1->GetNEntries(), r2->GetNEntries());
+   auto v1refid = r1->GetView<int32_t>("record.refid");
+   auto v2refid = r2->GetView<int32_t>("record.refid");
+   auto v1pos   = r1->GetView<int32_t>("record.pos");
+   auto v2pos   = r2->GetView<int32_t>("record.pos");
+   for (uint64_t i = 0; i < r1->GetNEntries(); ++i) {
+      EXPECT_EQ(v1refid(i), v2refid(i));
+      EXPECT_EQ(v1pos(i),   v2pos(i));
+   }
+   std::remove(doubleSorted);
+}
+
+TEST(RAMSortEdgeCases, MissingInputFileReturnsError)
+{
+   int ret = ramsortntuple("nonexistent.root", "/tmp/out.root");
+   EXPECT_NE(ret, 0);
+}
+
+} // namespace

--- a/tools/ramsort.cxx
+++ b/tools/ramsort.cxx
@@ -1,0 +1,27 @@
+/// \file ramsort.cxx
+/// \brief Command-line tool to sort a RAM (RNTuple) file by coordinate or name.
+///
+/// Usage:
+///   ./tools/ramsort <input.root> <output.root> [--by-name]
+
+#include "ramcore/RAMSort.h"
+#include <cstring>
+#include <iostream>
+
+int main(int argc, char **argv)
+{
+   if (argc < 3) {
+      std::cerr << "Usage: " << argv[0] << " <input.root> <output.root> [--by-name]\n";
+      std::cerr << "  Sort a RAM (RNTuple) file by genomic coordinate (refid, pos).\n";
+      std::cerr << "  --by-name  Sort by QNAME instead.\n";
+      return 1;
+   }
+
+   bool byName = false;
+   for (int i = 3; i < argc; ++i) {
+      if (std::strcmp(argv[i], "--by-name") == 0)
+         byName = true;
+   }
+
+   return ramsortntuple(argv[1], argv[2], byName);
+}


### PR DESCRIPTION
### Summary
This PR introduces a `ramsort` command-line tool that sorts RAM (RNTuple) files by genomic coordinate `(refid, pos)` or by query name (`QNAME`). It is the RNTuple-based equivalent of `samtools sort` and `samtools sort -n`.

### Motivation
Sorted alignment files are a prerequisite for most downstream bioinformatics analyses — region queries, variant calling, duplicate marking, and indexing all require coordinate-sorted input. This PR brings native sort capability to RAMTools without requiring conversion back to SAM/BAM.

### Changes

**New files:**
- `inc/ramcore/RAMSort.h` — `ramsortntuple()` function declaration
- `src/ramcore/RAMSort.cxx` — implementation using `RNTupleReader` field views and `std::stable_sort`
- `tools/ramsort.cxx` — command-line entry point
- `test/ramsorttests.cxx` — 5 Google Test cases

**Modified files:**
- `CMakeLists.txt` — added `RAMSort.h` and `RAMSort.cxx` to the `ramcore` library
- `tools/CMakeLists.txt` — added `ramsort` executable using `ROOT_EXECUTABLE` macro
- `test/CMakeLists.txt` — added `ramsorttests` test target

### Usage
```bash
# Coordinate sort (default) — equivalent to samtools sort
./tools/ramsort input.root output.root

# Name sort — equivalent to samtools sort -n
./tools/ramsort input.root output.root --by-name
```

### Implementation Notes
- Sort keys (`refid`, `pos`, `qname`) are read upfront into vectors for cache-efficient sorting
- Uses `std::stable_sort` to preserve relative order of reads with identical keys
- Records are written in sorted order using `RNTupleReader` views — no full deserialization until write time
- Reference name maps and index are preserved in the output file via `WriteAllRefs()` and `WriteIndex()`
- Sort logic lives in `src/ramcore/RAMSort.cxx` (library) — `tools/ramsort.cxx` is a thin CLI wrapper

### Tests
5 test cases in `test/ramsorttests.cxx` — all passing:
- `EntryCountPreserved` — sorted file has same number of entries as input
- `CoordinateSortOrder` — records are in non-decreasing `(refid, pos)` order after sort
- `NameSortOrder` — records are in non-decreasing `QNAME` lexicographic order after `--by-name`
- `IdempotentSort` — sorting an already sorted file produces identical coordinate order
- `MissingInputFileReturnsError` — graceful failure returns non-zero on bad input

### Test Results
```
100% tests passed, 0 tests failed out of 5
Total Test time (real) = 3.96 sec
```
