### PR TITLE
Simplify clang-tidy CI workflow and add htslib dependency

### DIFF
--- a/.github/workflows/clang-tidy-review.yml
+++ b/.github/workflows/clang-tidy-review.yml
@@ -10,10 +10,6 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
-permissions:
-  contents: read
-  pull-requests: write
-
 jobs:
   review:
     runs-on: ubuntu-24.04
@@ -32,27 +28,20 @@ jobs:
           version: '20.1.4'
 
       - name: Install lit
-        run: pip install --disable-pip-version-check --no-input lit
-
-      - name: Install ROOT
-        run: |
-          ROOT_URL="https://root.cern/download/root_v6.34.06.Linux-ubuntu24.04-x86_64-gcc13.3.tar.gz"
-          wget -O root.tar.gz "$ROOT_URL"
-          sudo tar -xzf root.tar.gz -C /opt/
-          echo "/opt/root/bin" >> "$GITHUB_PATH"
+        run: pip install lit
 
       - name: Run clang-tidy
         uses: ZedThree/clang-tidy-review@v0.21.0
         id: review
         with:
           build_dir: build
-          apt_packages: cmake,libxml2,libxml2-dev,libtinfo-dev,zlib1g-dev,libzstd-dev,libvdt-dev,libtbb-dev
+          apt_packages: cmake,libxml2,libxml2-dev,libtinfo-dev,zlib1g-dev,libzstd-dev,libvdt-dev,libtbb-dev,libhts-dev
           split_workflow: true
           config_file: .clang-tidy
-          clang_tidy_args: >
-            --extra-arg=-I${{ github.workspace }}/inc
-            --extra-arg=-I/opt/root/include
-            --extra-arg=-I${{ github.workspace }}/build/test/googletest-prefix/src/googletest/googletest/include
+          install_commands: |
+            wget -q -O root.tar.gz "https://root.cern/download/root_v6.34.06.Linux-ubuntu24.04-x86_64-gcc13.3.tar.gz" &&
+            tar -xzf root.tar.gz -C /opt/ &&
+            rm root.tar.gz
           cmake_command: >
             bash -x -c '
             source /opt/root/bin/thisroot.sh &&
@@ -71,4 +60,3 @@ jobs:
       - name: Upload artifacts
         if: always()
         uses: ZedThree/clang-tidy-review/upload@v0.21.0
-


### PR DESCRIPTION

Cleans up the clang-tidy review workflow by consolidating ROOT installation into the action's install_commands parameter instead of a separate step, and removes the manually specified `--extra-arg` include paths that the `CMake` build already handles.