### PR TITLE
enable implicit multithreading to improve compression performance

### DIFF
--- a/src/ramcore/SamToNTuple.cxx
+++ b/src/ramcore/SamToNTuple.cxx
@@ -21,6 +21,7 @@
 #include <string>
 #include <thread>
 #include <vector>
+#include <iostream>
 
 namespace {
 
@@ -36,14 +37,15 @@ void samtoramntuple(const char *datafile,
                     int compression_algorithm,
                     uint32_t quality_policy)
 {
-    TStopwatch stopwatch;
-    stopwatch.Start();
+   ROOT::EnableImplicitMT();
+   TStopwatch stopwatch;
+   stopwatch.Start();
 
-    auto rootFile = std::unique_ptr<TFile>(TFile::Open(treefile, "RECREATE"));
-    if (!rootFile || !rootFile->IsOpen()) {
-        printf("Failed to create RAM file %s\n", treefile);
-        return;
-    }
+   auto rootFile = std::unique_ptr<TFile>(TFile::Open(treefile, "RECREATE"));
+   if (!rootFile || !rootFile->IsOpen()) {
+      std::cout << "Failed to create RAM file " << treefile << "\n";
+      return;
+   }
 
     RAMNTupleRecord::InitializeRefs();
 


### PR DESCRIPTION
`RNTupleWriteOptions` enables implicit multithreading by default https://root.cern/doc/v636/classROOT_1_1RNTupleWriteOptions.html#a6b57fe45b76b33670c4b8b979ccff490 . But the multithreading needs to be enabled first using `EnableImplicitMT()` . 
On testing `samtoramntuple` tool on a 37GB SAM file converted from a BAM file obtained from the 1000 Genomes Project: https://ftp.1000genomes.ebi.ac.uk/vol1/ftp/phase1/data/HG00100/alignment/ 

Observations :
```
BAM FILE : HG00100.mapped.ILLUMINA.bwa.GBR.low_coverage.20101123.bam
BAM FILE SIZE : 8,752,906,441 bytes | ~8347 MB  | ~8.15 GB
SAM FILE : HG00100.sam
SAM FILE SIZE : 37,054,527,496 bytes | ~35,339 MB | ~34.5 GB

RUN 1 (develop branch)
RAM FILE : HG00100.ram
RAM FILE SIZE : 6,755,871,183 bytes | ~6443 MB | ~6.29 GB
COMPRESSION RATIO: ~5.488x
CONVERSION TIME (SAM TO RAM): Real time 0:21:32 | CP time 1215.140

RUN 2 (change 1)
CHANGE : called EnableImplicitMT();
REASON: RNTupleWriteOptions enables ImplicitMT by default but we need to enable the MT first
RAM FILE : HG00100.ram
RAM FILE SIZE : 6,755,871,183 bytes | ~6443 MB | ~6.29 GB ( no change)
COMPRESSION RATIO: ~5.488x (no change)
CONVERSION TIME (SAM TO RAM): Real time 0:09:02, CP time 1950.110 (~2.4x spedup with just 12 core multi threading)

RUN3 (change 2)
CHANGE: called EnableImplicitMT and change max unzipped page size to 1024*1024 and change aprox zipped cluster size to 256*1024*1024
REASON: Implicit MT runs the compression parallely using multiple cores so increasing the paze size would make sense
RAM FILE : HG00100.ram
RAM FILE SIZE : 6,755,871,183 bytes | ~6443 MB | ~6.29 GB ( no change)
COMPRESSION RATIO: ~5.488x (no change)
CONVERSION TIME (SAM TO RAM): Real time 0:09:00, CP time 1889.930 (not really much of a improvement than change 1)

```
complete logs can be found [here](https://docs.google.com/document/d/1DaH0IfuXW0o_ZomjK83DUg4ib8uV_ZfGRzTHs3cj6XU/edit?usp=sharing)


Monitoring the CPU utilization during run : 
Before change :  ( single core used )

<img width="1852" height="397" alt="one_core_used" src="https://github.com/user-attachments/assets/6af124fa-a9c0-4fc6-9848-2cf53b3a9fce" />

After change : ( multi cores utlized )
<img width="1851" height="394" alt="multiple_core_used" src="https://github.com/user-attachments/assets/50a6a9f7-588c-4380-a556-dee22ff3f607" />

- Utilization of all cores (12 for my system ) reduced the conversion time by ~2.4 times
- Data integrity was validated by running multiple region queries on both outputs using ramntupleview. all regions returned identical record counts, confirming that enabling implicit multithreading does not affect the dataset contents