### PR TITLE
Update CI and clang-tidy for BAM support

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -10,6 +10,8 @@ Checks: >
   performance-*,
   portability-*,
   readability-*,
+  -bugprone-branch-clone,
+  -bugprone-casting-through-void,
   -bugprone-narrowing-conversions,
   -bugprone-easily-swappable-parameters,
   -bugprone-implicit-widening-of-multiplication-result,
@@ -28,7 +30,9 @@ Checks: >
   -readability-function-cognitive-complexity,
   -readability-implicit-bool-conversion,
   -cppcoreguidelines-avoid-magic-numbers,
+  -cppcoreguidelines-pro-type-reinterpret-cast,
   -clang-analyzer-cplusplus.NewDeleteLeaks,
+  -llvm-header-guard,
 
 CheckOptions:
   - key:             readability-identifier-naming.ClassCase

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
     - name: Install build dependencies
       run: |
         sudo apt-get update
-        sudo apt-get install -y libvdt-dev libtbb-dev
+        sudo apt-get install -y libvdt-dev libtbb-dev libhts-dev
     
     - name: Configure CMake
       run: |
@@ -67,7 +67,7 @@ jobs:
     - name: Install build and coverage dependencies
       run: |
         sudo apt-get update
-        sudo apt-get install -y libvdt-dev libtbb-dev gcovr lcov
+        sudo apt-get install -y libvdt-dev libtbb-dev gcovr lcov libhts-dev
         
     - name: Configure with coverage
       run: |
@@ -96,7 +96,11 @@ jobs:
     - name: Generate coverage report
       run: |
         cd build
-        gcovr -r .. --xml-pretty --xml coverage.xml --print-summary
+        gcovr -r .. \
+          --xml-pretty --xml coverage.xml \
+          --exclude '../test/' \
+          --exclude '../benchmark/' \
+          --print-summary
         
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v5

--- a/.github/workflows/clang-tidy-review.yml
+++ b/.github/workflows/clang-tidy-review.yml
@@ -34,21 +34,18 @@ jobs:
       - name: Install lit
         run: pip install --disable-pip-version-check --no-input lit
 
-      - name: Install ROOT
-        run: |
-          ROOT_URL="https://root.cern/download/root_v6.34.06.Linux-ubuntu24.04-x86_64-gcc13.3.tar.gz"
-          wget -O root.tar.gz "$ROOT_URL"
-          sudo tar -xzf root.tar.gz -C /opt/
-          echo "/opt/root/bin" >> "$GITHUB_PATH"
-
       - name: Run clang-tidy
         uses: ZedThree/clang-tidy-review@v0.21.0
         id: review
         with:
           build_dir: build
-          apt_packages: cmake,libxml2,libxml2-dev,libtinfo-dev,zlib1g-dev,libzstd-dev,libvdt-dev,libtbb-dev
+          apt_packages: cmake,libxml2,libxml2-dev,libtinfo-dev,zlib1g-dev,libzstd-dev,libvdt-dev,libtbb-dev,libhts-dev,wget
           split_workflow: true
           config_file: .clang-tidy
+          install_commands: |
+            wget -q -O root.tar.gz "https://root.cern/download/root_v6.34.06.Linux-ubuntu24.04-x86_64-gcc13.3.tar.gz" &&
+            tar -xzf root.tar.gz -C /opt/ &&
+            rm root.tar.gz
           clang_tidy_args: >
             --extra-arg=-I${{ github.workspace }}/inc
             --extra-arg=-I/opt/root/include


### PR DESCRIPTION
- Add libhts-dev across CI jobs
- Move ROOT install into clang-tidy container via install_commands
- Disable false-positive checks for C interop (casting-through-void, reinterpret-cast, branch-clone, header-guard)
- Fix coverage excludes 