### PR TITLE
fix: replace atoi() with strict integer parsing in SamParser (#22)

### DIFF
--- a/src/ramcore/SamParser.cxx
+++ b/src/ramcore/SamParser.cxx
@@ -1,34 +1,31 @@
 #include "ramcore/SamParser.h"
-#include <cstring>
+#include <cerrno>
+#include <climits>
 #include <cstdlib>
-#include <stdexcept>
-#include <string>
+#include <cstring>
 #include <iostream>
 
 namespace ramcore {
 
 static bool StrictAtoi(const char* token, const char* field_name, int& result) {
-    try {
-        size_t pos = 0;
-        result = std::stoi(std::string(token), &pos);
-        if (pos != std::strlen(token)) {
-            std::cerr << "SamParser: invalid value '" << token
-                      << "' for field " << field_name
-                      << " (trailing characters)\n";
-            return false;
-        }
-        return true;
-    } catch (const std::invalid_argument&) {
+    char* end = nullptr;
+    errno = 0;
+    long val = strtol(token, &end, 10);
+
+    if (end == token || *end != '\0') {
         std::cerr << "SamParser: invalid value '" << token
                   << "' for field " << field_name
                   << " (not a number)\n";
         return false;
-    } catch (const std::out_of_range&) {
+    }
+    if (errno == ERANGE || val < INT_MIN || val > INT_MAX) {
         std::cerr << "SamParser: value '" << token
                   << "' for field " << field_name
                   << " is out of range\n";
         return false;
     }
+    result = static_cast<int>(val);
+    return true;
 }
 
 void StripCRLF(char* str) {

--- a/src/ramcore/SamParser.cxx
+++ b/src/ramcore/SamParser.cxx
@@ -1,8 +1,35 @@
 #include "ramcore/SamParser.h"
 #include <cstring>
 #include <cstdlib>
+#include <stdexcept>
+#include <string>
+#include <iostream>
 
 namespace ramcore {
+
+static bool StrictAtoi(const char* token, const char* field_name, int& result) {
+    try {
+        size_t pos = 0;
+        result = std::stoi(std::string(token), &pos);
+        if (pos != std::strlen(token)) {
+            std::cerr << "SamParser: invalid value '" << token
+                      << "' for field " << field_name
+                      << " (trailing characters)\n";
+            return false;
+        }
+        return true;
+    } catch (const std::invalid_argument&) {
+        std::cerr << "SamParser: invalid value '" << token
+                  << "' for field " << field_name
+                  << " (not a number)\n";
+        return false;
+    } catch (const std::out_of_range&) {
+        std::cerr << "SamParser: value '" << token
+                  << "' for field " << field_name
+                  << " is out of range\n";
+        return false;
+    }
+}
 
 void StripCRLF(char* str) {
     size_t len = strlen(str);
@@ -65,14 +92,14 @@ bool SamParser::ParseLine(char* line, SamRecord& record) {
     while (token) {
         switch (field_num) {
             case 0: record.qname = token; break;
-            case 1: record.flag = atoi(token); break;
+            case 1: if (!StrictAtoi(token, "FLAG", record.flag)) return false; break;
             case 2: record.rname = token; break;
-            case 3: record.pos = atoi(token); break;
-            case 4: record.mapq = atoi(token); break;
+            case 3: if (!StrictAtoi(token, "POS", record.pos)) return false; break;
+            case 4: if (!StrictAtoi(token, "MAPQ", record.mapq)) return false; break;
             case 5: record.cigar = token; break;
             case 6: record.rnext = token; break;
-            case 7: record.pnext = atoi(token); break;
-            case 8: record.tlen = atoi(token); break;
+            case 7: if (!StrictAtoi(token, "PNEXT", record.pnext)) return false; break;
+            case 8: if (!StrictAtoi(token, "TLEN", record.tlen)) return false; break;
             case 9: record.seq = token; break;
             case 10: 
                 StripCRLF(token);

--- a/test/ramcoretests.cxx
+++ b/test/ramcoretests.cxx
@@ -463,3 +463,39 @@ TEST_F(ramcoreTest, QUALEncodingDecodingModes)
    std::remove(samFile);
    std::remove(ramFile);
 }
+
+TEST_F(ramcoreTest, SamParserRejectsNonNumericFields)
+{
+   const char *badSam = "test_bad_fields.sam";
+   const char *rntupleFile = "test_bad_fields.root";
+
+   {
+      std::ofstream sam(badSam);
+      sam << "@HD\tVN:1.6\tSO:unsorted\n";
+      sam << "@SQ\tSN:chr1\tLN:10000\n";
+      // Non-numeric FLAG
+      sam << "read1\tBROKEN\tchr1\t100\t60\t50M\t*\t0\t0\t"
+          << std::string(50, 'A') << "\t*\n";
+      // Non-numeric POS
+      sam << "read2\t0\tchr1\tBAD\t60\t50M\t*\t0\t0\t"
+          << std::string(50, 'A') << "\t*\n";
+      // Trailing characters in MAPQ
+      sam << "read4\t0\tchr1\t300\t60abc\t50M\t*\t0\t0\t"
+          << std::string(50, 'A') << "\t*\n";
+      // Out-of-range POS
+      sam << "read5\t0\tchr1\t99999999999999\t60\t50M\t*\t0\t0\t"
+          << std::string(50, 'A') << "\t*\n";
+      // Valid record with negative TLEN
+      sam << "read3\t0\tchr1\t200\t60\t50M\t*\t0\t-150\t"
+          << std::string(50, 'A') << "\t*\n";
+   }
+
+   samtoramntuple(badSam, rntupleFile, false, false, false, 505, 0);
+
+   auto reader = ROOT::RNTupleReader::Open("RAM", rntupleFile);
+   EXPECT_EQ(reader->GetNEntries(), 1)
+      << "Only the valid record should be written; corrupted records must be rejected";
+
+   std::remove(badSam);
+   std::remove(rntupleFile);
+}


### PR DESCRIPTION
## Summary
- Replace all 5 unsafe `atoi()` calls in `SamParser::ParseLine` with a `StrictAtoi` helper that uses `std::stoi` with full validation
- Corrupted SAM records with non-numeric values in integer fields (`FLAG`, `POS`, `MAPQ`, `PNEXT`, `TLEN`) are now rejected instead of silently written with zeroed-out values
- Add unit test (`SamParserRejectsNonNumericFields`) verifying that invalid records are skipped while valid records in the same file are still processed

## Problem
`atoi()` returns `0` for non-numeric input without signaling an error. This caused silent data corruption: malformed SAM records were written to ROOT files with integer fields set to `0`, with no warning to the user.

## Solution
A static `StrictAtoi` function wraps `std::stoi` and:
- Validates that the **entire** token is consumed (rejects trailing characters like `"123abc"`)
- Catches `std::invalid_argument` for non-numeric strings
- Catches `std::out_of_range` for values exceeding `int` limits
- Prints a diagnostic to `stderr` identifying the field and invalid value
- Returns `false` so `ParseLine` skips the record

## Test plan
- [x] New test creates a SAM file with non-numeric FLAG and POS values plus one valid record
- [x] Asserts only the valid record is written to the output RNTuple (1 entry, not 3)
- [ ] `cmake --build build && cd build && ctest --output-on-failure` passes all tests

Closes #22