### PR TITLE
Revert back global suppressions 

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -10,8 +10,6 @@ Checks: >
   performance-*,
   portability-*,
   readability-*,
-  -bugprone-branch-clone,
-  -bugprone-casting-through-void,
   -bugprone-narrowing-conversions,
   -bugprone-easily-swappable-parameters,
   -bugprone-implicit-widening-of-multiplication-result,
@@ -30,9 +28,7 @@ Checks: >
   -readability-function-cognitive-complexity,
   -readability-implicit-bool-conversion,
   -cppcoreguidelines-avoid-magic-numbers,
-  -cppcoreguidelines-pro-type-reinterpret-cast,
   -clang-analyzer-cplusplus.NewDeleteLeaks,
-  -llvm-header-guard,
 
 CheckOptions:
   - key:             readability-identifier-naming.ClassCase


### PR DESCRIPTION
The PR reverts back some suppression checks introduced in this this PR(https://github.com/compiler-research/ramtools/pull/35)