### PR TITLE
Add Test Coverage for IndexGetRowsInRange

### DIFF
--- a/test/ramcoretests.cxx
+++ b/test/ramcoretests.cxx
@@ -16,6 +16,7 @@
 #include "../tools/ramview.cxx"
 #include "ramcore/RAMNTupleView.h"
 #include "ramcore/SamToNTuple.h"
+#include "rntuple/RAMNTupleRecord.h"
 #include "ramcore/SamToTTree.h"
 namespace {
 
@@ -31,6 +32,7 @@ protected:
         std::remove("test_ttree.root");
         std::remove("test_rntuple.root");
         std::remove("samexample.sam");
+        RAMNTupleRecord::GetIndex()->Clear();
     }
 };
 
@@ -179,27 +181,22 @@ TEST_F(ramcoreTest, IndexGetRowsInRange)
 {
    RAMNTupleRecord::InitializeRefs();
    auto index = RAMNTupleRecord::GetIndex();
-   index->Clear();
 
    index->AddItem(0, 100, 0);
    index->AddItem(0, 200, 1);
    index->AddItem(0, 300, 2);
    index->AddItem(1, 150, 3);
 
-   // Normal range
    auto rows = index->GetRowsInRange(0, 150, 250);
    ASSERT_EQ(rows.size(), 1u);
    EXPECT_EQ(rows[0], 1);
 
-   // Full range covers all entries on refid=0
    auto all = index->GetRowsInRange(0, 0, 400);
    EXPECT_EQ(all.size(), 3u);
 
-   // No entries in range
    auto none = index->GetRowsInRange(0, 400, 500);
    EXPECT_TRUE(none.empty());
 
-   // Different refid
    auto otherChrom = index->GetRowsInRange(1, 100, 200);
    ASSERT_EQ(otherChrom.size(), 1u);
    EXPECT_EQ(otherChrom[0], 3);

--- a/test/ramcoretests.cxx
+++ b/test/ramcoretests.cxx
@@ -217,7 +217,7 @@ TEST_F(ramcoreTest, IndexGetRowsInRange)
    auto wideRows = index->GetRowsInRange(/*refid=*/chr1_refid, /*start=*/0, /*end=*/1000000000);
    for (int64_t row : wideRows) {
       EXPECT_GE(row, 0);
-      EXPECT_LT(row, static_cast<int64_t>(reader->GetNEntries()));
+      EXPECT_LT(row, 100); // record length of samexample.sam is 100 in SetUp()
    }
 
    auto invalidRows = index->GetRowsInRange(/*refid=*/-1, /*start=*/0, /*end=*/1000000000);

--- a/test/ramcoretests.cxx
+++ b/test/ramcoretests.cxx
@@ -180,46 +180,47 @@ TEST_F(ramcoreTest, RNTupleViewFlagFiltering)
 TEST_F(ramcoreTest, IndexGetRowsInRange)
 {
    RAMNTupleRecord::InitializeRefs();
-   auto index = RAMNTupleRecord::GetIndex();
+   auto *index = RAMNTupleRecord::GetIndex();
 
    //  test with hard coded entries
-   index->AddItem(0, 100, 0);
-   index->AddItem(0, 200, 1);
-   index->AddItem(0, 300, 2);
-   index->AddItem(1, 150, 3);
-   
-   auto rows = index->GetRowsInRange(0, 150, 250);
-   ASSERT_EQ(rows.size(), 1u);
+   index->AddItem(/*refid=*/0, /*pos=*/100, /*row=*/0);
+   index->AddItem(/*refid=*/0, /*pos=*/200, /*row=*/1);
+   index->AddItem(/*refid=*/0, /*pos=*/300, /*row=*/2);
+   index->AddItem(/*refid=*/1, /*pos=*/150, /*row=*/3);
+
+   auto rows = index->GetRowsInRange(/*refid=*/0, /*start=*/150, /*end=*/250);
+   ASSERT_EQ(rows.size(), 1U);
    EXPECT_EQ(rows[0], 1);
 
-   auto all = index->GetRowsInRange(0, 0, 400);
-   EXPECT_EQ(all.size(), 3u);
+   auto all = index->GetRowsInRange(/*refid=*/0, /*start=*/0, /*end=*/400);
+   EXPECT_EQ(all.size(), 3U);
 
-   auto none = index->GetRowsInRange(0, 400, 500);
+   auto none = index->GetRowsInRange(/*refid=*/0, /*start=*/400, /*end=*/500);
    EXPECT_TRUE(none.empty());
 
-   auto otherChrom = index->GetRowsInRange(1, 100, 200);
-   ASSERT_EQ(otherChrom.size(), 1u);
+   auto otherChrom = index->GetRowsInRange(/*refid=*/1, /*start=*/100, /*end=*/200);
+   ASSERT_EQ(otherChrom.size(), 1U);
    EXPECT_EQ(otherChrom[0], 3);
 
    // test with generated entries
    const char *mockFile = "test_mock_index.root";
-   samtoramntuple("samexample.sam", mockFile, true, true, true, 505, 0);
+   samtoramntuple(/*datafile=*/"samexample.sam", mockFile, /*index=*/true, /*split=*/true, /*cache=*/true,
+                  /*compression_algorithm=*/505, /*quality_policy=*/0);
 
    auto reader = RAMNTupleRecord::OpenRAMFile(mockFile);
    ASSERT_NE(reader, nullptr);
-   EXPECT_GT(index->Size(), 0u);
+   EXPECT_GT(index->Size(), 0U);
 
    int chr1_refid = RAMNTupleRecord::GetRnameRefs()->GetRefId("chr1");
    EXPECT_GE(chr1_refid, 0);
 
-   auto wideRows = index->GetRowsInRange(chr1_refid, 0, 1000000000);
+   auto wideRows = index->GetRowsInRange(/*refid=*/chr1_refid, /*start=*/0, /*end=*/1000000000);
    for (int64_t row : wideRows) {
       EXPECT_GE(row, 0);
       EXPECT_LT(row, static_cast<int64_t>(reader->GetNEntries()));
    }
-   
-   auto invalidRows = index->GetRowsInRange(-1, 0, 1000000000);
+
+   auto invalidRows = index->GetRowsInRange(/*refid=*/-1, /*start=*/0, /*end=*/1000000000);
    EXPECT_TRUE(invalidRows.empty());
 
    std::remove(mockFile);

--- a/test/ramcoretests.cxx
+++ b/test/ramcoretests.cxx
@@ -261,3 +261,33 @@ TEST_F(ramcoreTest, SmartIndexRespectsPositionInterval)
    std::remove(customSam);
    std::remove(rntupleFile);
 }
+
+TEST_F(ramcoreTest, IndexGetRowsInRange)
+{
+   RAMNTupleRecord::InitializeRefs();
+   auto index = RAMNTupleRecord::GetIndex();
+   index->Clear();
+
+   index->AddItem(0, 100, 0);
+   index->AddItem(0, 200, 1);
+   index->AddItem(0, 300, 2);
+   index->AddItem(1, 150, 3);
+
+   // Normal range
+   auto rows = index->GetRowsInRange(0, 150, 250);
+   ASSERT_EQ(rows.size(), 1u);
+   EXPECT_EQ(rows[0], 1);
+
+   // Full range covers all entries on refid=0
+   auto all = index->GetRowsInRange(0, 0, 400);
+   EXPECT_EQ(all.size(), 3u);
+
+   // No entries in range
+   auto none = index->GetRowsInRange(0, 400, 500);
+   EXPECT_TRUE(none.empty());
+
+   // Different refid
+   auto otherChrom = index->GetRowsInRange(1, 100, 200);
+   ASSERT_EQ(otherChrom.size(), 1u);
+   EXPECT_EQ(otherChrom[0], 3);
+}

--- a/test/ramcoretests.cxx
+++ b/test/ramcoretests.cxx
@@ -175,6 +175,36 @@ TEST_F(ramcoreTest, RNTupleViewFlagFiltering)
    std::remove(rntupleFile);
 }
 
+TEST_F(ramcoreTest, IndexGetRowsInRange)
+{
+   RAMNTupleRecord::InitializeRefs();
+   auto index = RAMNTupleRecord::GetIndex();
+   index->Clear();
+
+   index->AddItem(0, 100, 0);
+   index->AddItem(0, 200, 1);
+   index->AddItem(0, 300, 2);
+   index->AddItem(1, 150, 3);
+
+   // Normal range
+   auto rows = index->GetRowsInRange(0, 150, 250);
+   ASSERT_EQ(rows.size(), 1u);
+   EXPECT_EQ(rows[0], 1);
+
+   // Full range covers all entries on refid=0
+   auto all = index->GetRowsInRange(0, 0, 400);
+   EXPECT_EQ(all.size(), 3u);
+
+   // No entries in range
+   auto none = index->GetRowsInRange(0, 400, 500);
+   EXPECT_TRUE(none.empty());
+
+   // Different refid
+   auto otherChrom = index->GetRowsInRange(1, 100, 200);
+   ASSERT_EQ(otherChrom.size(), 1u);
+   EXPECT_EQ(otherChrom[0], 3);
+}
+
 } // namespace
 
 TEST_F(ramcoreTest, SmartIndexSkipsUnmappedReads)
@@ -260,34 +290,4 @@ TEST_F(ramcoreTest, SmartIndexRespectsPositionInterval)
 
    std::remove(customSam);
    std::remove(rntupleFile);
-}
-
-TEST_F(ramcoreTest, IndexGetRowsInRange)
-{
-   RAMNTupleRecord::InitializeRefs();
-   auto index = RAMNTupleRecord::GetIndex();
-   index->Clear();
-
-   index->AddItem(0, 100, 0);
-   index->AddItem(0, 200, 1);
-   index->AddItem(0, 300, 2);
-   index->AddItem(1, 150, 3);
-
-   // Normal range
-   auto rows = index->GetRowsInRange(0, 150, 250);
-   ASSERT_EQ(rows.size(), 1u);
-   EXPECT_EQ(rows[0], 1);
-
-   // Full range covers all entries on refid=0
-   auto all = index->GetRowsInRange(0, 0, 400);
-   EXPECT_EQ(all.size(), 3u);
-
-   // No entries in range
-   auto none = index->GetRowsInRange(0, 400, 500);
-   EXPECT_TRUE(none.empty());
-
-   // Different refid
-   auto otherChrom = index->GetRowsInRange(1, 100, 200);
-   ASSERT_EQ(otherChrom.size(), 1u);
-   EXPECT_EQ(otherChrom[0], 3);
 }

--- a/test/ramcoretests.cxx
+++ b/test/ramcoretests.cxx
@@ -182,11 +182,12 @@ TEST_F(ramcoreTest, IndexGetRowsInRange)
    RAMNTupleRecord::InitializeRefs();
    auto index = RAMNTupleRecord::GetIndex();
 
+   //  test with hard coded entries
    index->AddItem(0, 100, 0);
    index->AddItem(0, 200, 1);
    index->AddItem(0, 300, 2);
    index->AddItem(1, 150, 3);
-
+   
    auto rows = index->GetRowsInRange(0, 150, 250);
    ASSERT_EQ(rows.size(), 1u);
    EXPECT_EQ(rows[0], 1);
@@ -200,6 +201,28 @@ TEST_F(ramcoreTest, IndexGetRowsInRange)
    auto otherChrom = index->GetRowsInRange(1, 100, 200);
    ASSERT_EQ(otherChrom.size(), 1u);
    EXPECT_EQ(otherChrom[0], 3);
+
+   // test with generated entries
+   const char *mockFile = "test_mock_index.root";
+   samtoramntuple("samexample.sam", mockFile, true, true, true, 505, 0);
+
+   auto reader = RAMNTupleRecord::OpenRAMFile(mockFile);
+   ASSERT_NE(reader, nullptr);
+   EXPECT_GT(index->Size(), 0u);
+
+   int chr1_refid = RAMNTupleRecord::GetRnameRefs()->GetRefId("chr1");
+   EXPECT_GE(chr1_refid, 0);
+
+   auto wideRows = index->GetRowsInRange(chr1_refid, 0, 1000000000);
+   for (int64_t row : wideRows) {
+      EXPECT_GE(row, 0);
+      EXPECT_LT(row, static_cast<int64_t>(reader->GetNEntries()));
+   }
+   
+   auto invalidRows = index->GetRowsInRange(-1, 0, 1000000000);
+   EXPECT_TRUE(invalidRows.empty());
+
+   std::remove(mockFile);
 }
 
 } // namespace


### PR DESCRIPTION
Contributes to issue #26.

This PR adds a test for `IndexGetRowsInRange()` from `src/rntuple/RAMNTupleRecord.cxx` inside `test/ramcoretests.cxx`.

It includes two sets of tests. One with a hard-coded 4 element vector, the other is with `GenerateSAMFile()` directly.


#### Additional Comments
After scanning through CodeCov: https://app.codecov.io/gh/compiler-research/ramtools/tree/develop/. I noticed that, aside from the legacy `TTree` files, the only file that still lacking most code coverage is `src/rntuple/RAMNTupleRecord.cxx`. 

You may notice that for my code, I included parameter names inside comments. Such as `samtoramntuple(/*datafile=*/samFile, ...);`  instead just `samtoramntuple(samFile, ...);`
This was done to make the warnings in `clang-tidy` go away. If this is not necessary, feel free to let me know!