### PR TITLE
Fix DecodeSequence bug

### DIFF
--- a/src/rntuple/RAMNTupleRecord.cxx
+++ b/src/rntuple/RAMNTupleRecord.cxx
@@ -439,6 +439,7 @@ std::string DecodeSequence(const std::string &encoded_seq, size_t length)
       seq[i * 2 + 1] = kCodeToSeq[byte & 0xf];
    }
    if (length % 2) {
+      // NOLINTNEXTLINE
       seq[length - 1] = kCodeToSeq[static_cast<uint8_t>(encoded_seq[length / 2]) >> 4];
    }
 

--- a/src/rntuple/RAMNTupleRecord.cxx
+++ b/src/rntuple/RAMNTupleRecord.cxx
@@ -439,7 +439,7 @@ std::string DecodeSequence(const std::string &encoded_seq, size_t length)
       seq[i * 2 + 1] = kCodeToSeq[byte & 0xf];
    }
    if (length % 2) {
-      // NOLINTNEXTLINE
+      // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
       seq[length - 1] = kCodeToSeq[static_cast<uint8_t>(encoded_seq[length / 2]) >> 4];
    }
 

--- a/src/rntuple/RAMNTupleRecord.cxx
+++ b/src/rntuple/RAMNTupleRecord.cxx
@@ -439,7 +439,7 @@ std::string DecodeSequence(const std::string &encoded_seq, size_t length)
       seq[i * 2 + 1] = kCodeToSeq[byte & 0xf];
    }
    if (length % 2) {
-      seq[length - 1] = kCodeToSeq[encoded_seq[length / 2] >> 4];
+      seq[length - 1] = kCodeToSeq[static_cast<uint8_t>(encoded_seq[length / 2]) >> 4];
    }
 
    return seq;

--- a/test/ramcoretests.cxx
+++ b/test/ramcoretests.cxx
@@ -265,6 +265,8 @@ TEST_F(ramcoreTest, RecordGetters)
    EXPECT_EQ(record.GetCIGAROP(/*idx=*/9), 0);
 
    // all 15 IUPAC bases
+   record.SetSEQ("ATT");
+   EXPECT_EQ(record.GetSEQ(), "ATT");
    record.SetSEQ("=ACMGRSVTWYHKDBN");
    EXPECT_EQ(record.GetSEQ(), "=ACMGRSVTWYHKDBN");
    record.SetSEQ("");


### PR DESCRIPTION
Fixes Issue #44.

I also added the testcase that broke `GetSeq()` back in `ramcoretests.cxx`.

#### Problem Summary

Example

```
RAMNTupleRecord record;
record.SetSEQ("ATT");
std::cout << record.GetSEQ() << std::endl;
```
Returns `AT\0` instead `ATT`.

Specifically, this bug happens when the sequence is odd length, with the final character being `T,W,Y,H,K,D,B,N`. 
The outcome of this bug is that the final character will be missing or incorrect.

#### The Fix

Inspecting the definition for `DecodeSequence()`, at line `442`,
```
 if (length % 2) {
    seq[length - 1] = kCodeToSeq[encoded_seq[length / 2] >> 4];
 }
```

The problem is that `encoded_seq[length / 2]` returns a `Char`. To fix this, cast it to `uint8_t`.

``` 
if (length % 2) {
    seq[length - 1] = kCodeToSeq[static_cast<uint8_t>(encoded_seq[length / 2]) >> 4];
 }
```

#### Explanation

Suppose the last character is `T`, `encoded_seq[length / 2]` in bit representation would be `1000 0000`,

```
char:    1000 0000 >> 4 = 1111 1000  (-8,  shift fills with 1s)
uint8_t: 1000 0000 >> 4 = 0000 1000  ( 8,  shift fills with 0s)
```

The original representation uses the former, and as we can see, it returns a negative index.

Hope this makes sense!







