### PR TITLE
fix: validate SamParser integers and stop fRefVec pollution

### DIFF
--- a/inc/rntuple/RAMNTupleRecord.h
+++ b/inc/rntuple/RAMNTupleRecord.h
@@ -39,6 +39,7 @@ public:
    ~RAMNTupleRefs() = default;
 
    int GetRefId(const std::string &rname);
+   int FindRefId(const std::string &rname) const; ///< Lookup-only; returns -1 if not found.
    const std::string &GetRefName(int rid) const;
 
    void Print() const;

--- a/src/ramcore/SamParser.cxx
+++ b/src/ramcore/SamParser.cxx
@@ -1,9 +1,10 @@
 #include "ramcore/SamParser.h"
-#include <cerrno>
 #include <cctype>
+#include <cerrno>
+#include <cstddef>
 #include <cstdint>
-#include <cstring>
 #include <cstdlib>
+#include <cstring>
 #include <iostream>
 #include <limits>
 
@@ -13,141 +14,141 @@ namespace {
 
 bool ParseInt(const char *value, int &out, const char *field_name, size_t line_number, int min_value, int max_value)
 {
-    if (!value || *value == '\0') {
-        std::cerr << "[SamParser] Warning: empty value for field '" << field_name << "' at line " << line_number
-                  << "; record skipped.\n";
-        return false;
-    }
-    if (std::isspace(static_cast<unsigned char>(*value))) {
-        std::cerr << "[SamParser] Warning: invalid integer value '" << value << "' for field '" << field_name
-                  << "' at line " << line_number << "; record skipped.\n";
-        return false;
-    }
+   if (!value || *value == '\0') {
+      std::cerr << "[SamParser] Warning: empty value for field '" << field_name << "' at line " << line_number
+                << "; record skipped.\n";
+      return false;
+   }
+   if (std::isspace(static_cast<unsigned char>(*value))) {
+      std::cerr << "[SamParser] Warning: invalid integer value '" << value << "' for field '" << field_name
+                << "' at line " << line_number << "; record skipped.\n";
+      return false;
+   }
 
-    errno = 0;
-    char *end = nullptr;
-    long parsed = std::strtol(value, &end, 10);
+   errno = 0;
+   char *end = nullptr;
+   long parsed = std::strtol(value, &end, 10);
 
-    if (end == value || *end != '\0') {
-        std::cerr << "[SamParser] Warning: invalid integer value '" << value << "' for field '" << field_name
-                  << "' at line " << line_number << "; record skipped.\n";
-        return false;
-    }
+   if (end == value || *end != '\0') {
+      std::cerr << "[SamParser] Warning: invalid integer value '" << value << "' for field '" << field_name
+                << "' at line " << line_number << "; record skipped.\n";
+      return false;
+   }
 
-    if (errno == ERANGE || parsed < min_value || parsed > max_value) {
-        std::cerr << "[SamParser] Warning: integer value '" << value << "' for field '" << field_name
-                  << "' is out of range at line " << line_number << "; record skipped.\n";
-        return false;
-    }
+   if (errno == ERANGE || parsed < min_value || parsed > max_value) {
+      std::cerr << "[SamParser] Warning: integer value '" << value << "' for field '" << field_name
+                << "' is out of range at line " << line_number << "; record skipped.\n";
+      return false;
+   }
 
-    out = static_cast<int>(parsed);
-    return true;
+   out = static_cast<int>(parsed);
+   return true;
 }
 
 } // namespace
 
-void StripCRLF(char* str) {
-    size_t len = strlen(str);
-    while (len > 0 && (str[len-1] == '\n' || str[len-1] == '\r')) {
-        str[--len] = '\0';
-    }
+void StripCRLF(char *str)
+{
+   size_t len = strlen(str);
+   while (len > 0 && (str[len - 1] == '\n' || str[len - 1] == '\r')) {
+      str[--len] = '\0';
+   }
 }
 
-bool SamParser::ParseFile(const char* filename, 
-                         HeaderCallback header_cb, 
-                         RecordCallback record_cb) {
-    FILE* fp = fopen(filename, "r");
-    if (!fp) {
-        return false;
-    }
-    
-    lines_processed_ = 0;
-    records_processed_ = 0;
-    
-    char line[kMaxLineLength];
-    SamRecord record;
-    
-    while (fgets(line, kMaxLineLength, fp)) {
-        lines_processed_++;
-        
-        if (line[0] == '@') {
-            char* tab = strchr(line, '\t');
-            if (tab) {
-                *tab = '\0';
-                StripCRLF(tab + 1);
-                if (header_cb) {
-                    header_cb(line, tab + 1);
-                }
-            } else {
-                StripCRLF(line);
-                if (header_cb) {
-                    header_cb(line, "");
-                }
+bool SamParser::ParseFile(const char *filename, HeaderCallback header_cb, RecordCallback record_cb)
+{
+   FILE *fp = fopen(filename, "r");
+   if (!fp) {
+      return false;
+   }
+
+   lines_processed_ = 0;
+   records_processed_ = 0;
+
+   char line[kMaxLineLength];
+   SamRecord record;
+
+   while (fgets(line, kMaxLineLength, fp)) {
+      lines_processed_++;
+
+      if (line[0] == '@') {
+         char *tab = strchr(line, '\t');
+         if (tab) {
+            *tab = '\0';
+            StripCRLF(tab + 1);
+            if (header_cb) {
+               header_cb(line, tab + 1);
             }
-            continue;
-        }
-        
-        record.Clear();
-        if (ParseLine(line, record)) {
-            if (record_cb) {
-                record_cb(record, records_processed_);
+         } else {
+            StripCRLF(line);
+            if (header_cb) {
+               header_cb(line, "");
             }
-            records_processed_++;
-        }
-    }
-    
-    fclose(fp);
-    return true;
+         }
+         continue;
+      }
+
+      record.Clear();
+      if (ParseLine(line, record)) {
+         if (record_cb) {
+            record_cb(record, records_processed_);
+         }
+         records_processed_++;
+      }
+   }
+
+   fclose(fp);
+   return true;
 }
 
-bool SamParser::ParseLine(char* line, SamRecord& record) {
-    int field_num = 0;
-    char* token = strtok(line, "\t");
-    
-    while (token) {
-        switch (field_num) {
-            case 0: record.qname = token; break;
-            case 1:
-                if (!ParseInt(token, record.flag, "flag", lines_processed_, 0, std::numeric_limits<uint16_t>::max()))
-                    return false;
-                break;
-            case 2: record.rname = token; break;
-            case 3:
-                if (!ParseInt(token, record.pos, "pos", lines_processed_, 0, std::numeric_limits<int>::max()))
-                    return false;
-                break;
-            case 4:
-                if (!ParseInt(token, record.mapq, "mapq", lines_processed_, 0, std::numeric_limits<uint8_t>::max()))
-                    return false;
-                break;
-            case 5: record.cigar = token; break;
-            case 6: record.rnext = token; break;
-            case 7:
-                if (!ParseInt(token, record.pnext, "pnext", lines_processed_, 0, std::numeric_limits<int>::max()))
-                    return false;
-                break;
-            case 8:
-                if (!ParseInt(token, record.tlen, "tlen", lines_processed_, std::numeric_limits<int>::min() + 1,
-                              std::numeric_limits<int>::max()))
-                    return false;
-                break;
-            case 9: record.seq = token; break;
-            case 10: 
-                StripCRLF(token);
-                record.qual = token; 
-                break;
-            default:
-                StripCRLF(token);
-                record.optional_fields.push_back(token);
-                break;
-        }
-        
-        field_num++;
-        token = strtok(nullptr, "\t");
-    }
-    
-    return field_num >= 11; 
+bool SamParser::ParseLine(char *line, SamRecord &record)
+{
+   int field_num = 0;
+   char *token = strtok(line, "\t");
+
+   while (token) {
+      switch (field_num) {
+      case 0: record.qname = token; break;
+      case 1:
+         if (!ParseInt(token, record.flag, "flag", lines_processed_, 0, std::numeric_limits<std::uint16_t>::max()))
+            return false;
+         break;
+      case 2: record.rname = token; break;
+      case 3:
+         if (!ParseInt(token, record.pos, "pos", lines_processed_, 0, std::numeric_limits<int>::max()))
+            return false;
+         break;
+      case 4:
+         if (!ParseInt(token, record.mapq, "mapq", lines_processed_, 0, std::numeric_limits<std::uint8_t>::max()))
+            return false;
+         break;
+      case 5: record.cigar = token; break;
+      case 6: record.rnext = token; break;
+      case 7:
+         if (!ParseInt(token, record.pnext, "pnext", lines_processed_, 0, std::numeric_limits<int>::max()))
+            return false;
+         break;
+      case 8:
+         if (!ParseInt(token, record.tlen, "tlen", lines_processed_, std::numeric_limits<int>::min() + 1,
+                       std::numeric_limits<int>::max()))
+            return false;
+         break;
+      case 9: record.seq = token; break;
+      case 10:
+         StripCRLF(token);
+         record.qual = token;
+         break;
+      default:
+         StripCRLF(token);
+         record.optional_fields.push_back(token);
+         break;
+      }
+
+      field_num++;
+      token = strtok(nullptr, "\t");
+   }
+
+   return field_num >= 11;
 }
 
-} 
-
+} // namespace ramcore

--- a/src/ramcore/SamParser.cxx
+++ b/src/ramcore/SamParser.cxx
@@ -2,7 +2,6 @@
 #include <cctype>
 #include <cerrno>
 #include <cstddef>
-#include <cstdint>
 #include <cstdlib>
 #include <cstring>
 #include <iostream>
@@ -47,10 +46,13 @@ bool ParseInt(const char *value, int &out, const char *field_name, size_t line_n
 
 } // namespace
 
+// NOLINTNEXTLINE(misc-use-internal-linkage)
 void StripCRLF(char *str)
 {
    size_t len = strlen(str);
+   // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
    while (len > 0 && (str[len - 1] == '\n' || str[len - 1] == '\r')) {
+      // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
       str[--len] = '\0';
    }
 }
@@ -110,7 +112,7 @@ bool SamParser::ParseLine(char *line, SamRecord &record)
       switch (field_num) {
       case 0: record.qname = token; break;
       case 1:
-         if (!ParseInt(token, record.flag, "flag", lines_processed_, 0, std::numeric_limits<std::uint16_t>::max()))
+         if (!ParseInt(token, record.flag, "flag", lines_processed_, 0, std::numeric_limits<unsigned short>::max()))
             return false;
          break;
       case 2: record.rname = token; break;
@@ -119,7 +121,7 @@ bool SamParser::ParseLine(char *line, SamRecord &record)
             return false;
          break;
       case 4:
-         if (!ParseInt(token, record.mapq, "mapq", lines_processed_, 0, std::numeric_limits<std::uint8_t>::max()))
+         if (!ParseInt(token, record.mapq, "mapq", lines_processed_, 0, std::numeric_limits<unsigned char>::max()))
             return false;
          break;
       case 5: record.cigar = token; break;

--- a/src/ramcore/SamParser.cxx
+++ b/src/ramcore/SamParser.cxx
@@ -1,8 +1,50 @@
 #include "ramcore/SamParser.h"
+#include <cerrno>
+#include <cctype>
+#include <cstdint>
 #include <cstring>
 #include <cstdlib>
+#include <iostream>
+#include <limits>
 
 namespace ramcore {
+
+namespace {
+
+bool ParseInt(const char *value, int &out, const char *field_name, size_t line_number, int min_value, int max_value)
+{
+    if (!value || *value == '\0') {
+        std::cerr << "[SamParser] Warning: empty value for field '" << field_name << "' at line " << line_number
+                  << "; record skipped.\n";
+        return false;
+    }
+    if (std::isspace(static_cast<unsigned char>(*value))) {
+        std::cerr << "[SamParser] Warning: invalid integer value '" << value << "' for field '" << field_name
+                  << "' at line " << line_number << "; record skipped.\n";
+        return false;
+    }
+
+    errno = 0;
+    char *end = nullptr;
+    long parsed = std::strtol(value, &end, 10);
+
+    if (end == value || *end != '\0') {
+        std::cerr << "[SamParser] Warning: invalid integer value '" << value << "' for field '" << field_name
+                  << "' at line " << line_number << "; record skipped.\n";
+        return false;
+    }
+
+    if (errno == ERANGE || parsed < min_value || parsed > max_value) {
+        std::cerr << "[SamParser] Warning: integer value '" << value << "' for field '" << field_name
+                  << "' is out of range at line " << line_number << "; record skipped.\n";
+        return false;
+    }
+
+    out = static_cast<int>(parsed);
+    return true;
+}
+
+} // namespace
 
 void StripCRLF(char* str) {
     size_t len = strlen(str);
@@ -65,14 +107,30 @@ bool SamParser::ParseLine(char* line, SamRecord& record) {
     while (token) {
         switch (field_num) {
             case 0: record.qname = token; break;
-            case 1: record.flag = atoi(token); break;
+            case 1:
+                if (!ParseInt(token, record.flag, "flag", lines_processed_, 0, std::numeric_limits<uint16_t>::max()))
+                    return false;
+                break;
             case 2: record.rname = token; break;
-            case 3: record.pos = atoi(token); break;
-            case 4: record.mapq = atoi(token); break;
+            case 3:
+                if (!ParseInt(token, record.pos, "pos", lines_processed_, 0, std::numeric_limits<int>::max()))
+                    return false;
+                break;
+            case 4:
+                if (!ParseInt(token, record.mapq, "mapq", lines_processed_, 0, std::numeric_limits<uint8_t>::max()))
+                    return false;
+                break;
             case 5: record.cigar = token; break;
             case 6: record.rnext = token; break;
-            case 7: record.pnext = atoi(token); break;
-            case 8: record.tlen = atoi(token); break;
+            case 7:
+                if (!ParseInt(token, record.pnext, "pnext", lines_processed_, 0, std::numeric_limits<int>::max()))
+                    return false;
+                break;
+            case 8:
+                if (!ParseInt(token, record.tlen, "tlen", lines_processed_, std::numeric_limits<int>::min() + 1,
+                              std::numeric_limits<int>::max()))
+                    return false;
+                break;
             case 9: record.seq = token; break;
             case 10: 
                 StripCRLF(token);

--- a/src/rntuple/RAMNTupleRecord.cxx
+++ b/src/rntuple/RAMNTupleRecord.cxx
@@ -69,6 +69,18 @@ int RAMNTupleRefs::GetRefId(const std::string &rname)
    return fLastId;
 }
 
+int RAMNTupleRefs::FindRefId(const std::string &rname) const
+{
+   if (rname == "*")
+      return -1;
+   if (rname == fLastName)
+      return fLastId;
+   auto it = std::find(fRefVec.begin(), fRefVec.end(), rname);
+   if (it != fRefVec.end())
+      return static_cast<int>(std::distance(fRefVec.begin(), it));
+   return -1;
+}
+
 const std::string &RAMNTupleRefs::GetRefName(int rid) const
 {
    static const std::string star = "*";
@@ -711,7 +723,7 @@ void RAMNTupleConverter::ViewRegion(const std::string &ram_file, const std::stri
    }
 
    auto refs = RAMNTupleRecord::GetRnameRefs();
-   int32_t ref_id = refs ? refs->GetRefId(ref_name) : -1;
+   int32_t ref_id = refs ? refs->FindRefId(ref_name) : -1;
 
    if (ref_id < 0) {
       ::Error("ViewRegion", "Unknown reference sequence: %s", ref_name.c_str());

--- a/src/rntuple/RAMNTupleRecord.cxx
+++ b/src/rntuple/RAMNTupleRecord.cxx
@@ -759,4 +759,3 @@ void RAMNTupleConverter::ViewRegion(const std::string &ram_file, const std::stri
       std::cout << "Found " << count << " reads in region " << region << std::endl;
    }
 }
-

--- a/test/ramcoretests.cxx
+++ b/test/ramcoretests.cxx
@@ -10,10 +10,10 @@
 #include <cstring>
 #include <filesystem>
 #include <fstream>
+#include <initializer_list>
 #include <iostream>
 #include <limits>
 #include <string>
-#include <vector>
 #include "../benchmark/generate_sam_benchmark.h"
 #include "../tools/ramview.cxx"
 #include "ramcore/RAMNTupleView.h"
@@ -25,23 +25,26 @@ namespace {
 
 class ramcoreTest : public ::testing::Test {
 protected:
-    static constexpr const char *kParserTestFile = "test_sam_parser_validation.sam";
+   static constexpr const char *kParserTestFile = "test_sam_parser_validation.sam";
 
-    void SetUp() override {
-       GenerateSAMFile("samexample.sam", 100);
-       std::remove("test_ttree.root");
-       std::remove("test_rntuple.root");
-    }
+   void SetUp() override
+   {
+      GenerateSAMFile("samexample.sam", 100);
+      std::remove("test_ttree.root");
+      std::remove("test_rntuple.root");
+   }
 
-    void TearDown() override {
-        std::remove("test_ttree.root");
-        std::remove("test_rntuple.root");
-        std::remove("samexample.sam");
-        std::remove(kParserTestFile);
-        RAMNTupleRecord::GetIndex()->Clear();
-    }
+   void TearDown() override
+   {
+      std::remove("test_ttree.root");
+      std::remove("test_rntuple.root");
+      std::remove("samexample.sam");
+      std::remove(kParserTestFile);
+      RAMNTupleRecord::GetIndex()->Clear();
+   }
 
-   size_t ParseSamRecords(const std::vector<std::string> &records, ramcore::SamRecord *last_record = nullptr)
+   template <typename OnRecord>
+   static size_t ParseSamRecords(std::initializer_list<const char *> records, OnRecord on_record)
    {
       {
          std::ofstream sam(kParserTestFile);
@@ -54,19 +57,25 @@ protected:
 
       size_t count = 0;
       ramcore::SamParser parser;
-      const bool parsed = parser.ParseFile(kParserTestFile, [](const std::string &, const std::string &) {},
-                                           [&](const ramcore::SamRecord &record, size_t) {
-                                              ++count;
-                                              if (last_record)
-                                                 *last_record = record;
-                                           });
+      const bool parsed = parser.ParseFile(
+         kParserTestFile, [](const std::string &, const std::string &) {},
+         [&](const ramcore::SamRecord &record, size_t) {
+            ++count;
+            on_record(record);
+         });
 
       EXPECT_TRUE(parsed);
       return count;
    }
+
+   static size_t ParseSamRecords(std::initializer_list<const char *> records)
+   {
+      return ParseSamRecords(records, [](const ramcore::SamRecord &) {});
+   }
 };
 
-TEST_F(ramcoreTest, ConversionProducesEqualEntries) {
+TEST_F(ramcoreTest, ConversionProducesEqualEntries)
+{
    const char *samFile = "samexample.sam";
    const char *ttreeFile = "test_ttree.root";
    const char *rntupleFile = "test_rntuple.root";
@@ -414,28 +423,28 @@ TEST_F(ramcoreTest, SmartIndexRespectsPositionInterval)
    std::remove(rntupleFile);
 }
 
+// NOLINTNEXTLINE(misc-use-internal-linkage)
 TEST_F(ramcoreTest, SamParserRejectsMalformedIntegerFields)
 {
-   const std::vector<std::string> records = {
-      "bad_flag\tabc\tchr1\t100\t60\t10M\t*\t0\t0\tACGT\tIIII",
-      "bad_flag_space\t 1\tchr1\t100\t60\t10M\t*\t0\t0\tACGT\tIIII",
-      "bad_pos\t0\tchr1\t12x\t60\t10M\t*\t0\t0\tACGT\tIIII",
-      "bad_mapq\t0\tchr1\t100\t256\t10M\t*\t0\t0\tACGT\tIIII",
-      "bad_pnext\t0\tchr1\t100\t60\t10M\t*\t-1\t0\tACGT\tIIII",
-      "bad_tlen_min\t0\tchr1\t100\t60\t10M\t*\t0\t-2147483648\tACGT\tIIII",
-      "bad_tlen\t0\tchr1\t100\t60\t10M\t*\t0\t999999999999999999999\tACGT\tIIII",
-      "good\t0\tchr1\t200\t60\t10M\t*\t0\t0\tACGT\tIIII"};
-
-   EXPECT_EQ(ParseSamRecords(records), 1U);
+   EXPECT_EQ(ParseSamRecords({"bad_flag\tabc\tchr1\t100\t60\t10M\t*\t0\t0\tACGT\tIIII",
+                              "bad_flag_space\t 1\tchr1\t100\t60\t10M\t*\t0\t0\tACGT\tIIII",
+                              "bad_pos\t0\tchr1\t12x\t60\t10M\t*\t0\t0\tACGT\tIIII",
+                              "bad_mapq\t0\tchr1\t100\t256\t10M\t*\t0\t0\tACGT\tIIII",
+                              "bad_pnext\t0\tchr1\t100\t60\t10M\t*\t-1\t0\tACGT\tIIII",
+                              "bad_tlen_min\t0\tchr1\t100\t60\t10M\t*\t0\t-2147483648\tACGT\tIIII",
+                              "bad_tlen\t0\tchr1\t100\t60\t10M\t*\t0\t999999999999999999999\tACGT\tIIII",
+                              "good\t0\tchr1\t200\t60\t10M\t*\t0\t0\tACGT\tIIII"}),
+             1U);
 }
 
+// NOLINTNEXTLINE(misc-use-internal-linkage)
 TEST_F(ramcoreTest, SamParserParsesValidIntegerBoundaries)
 {
    ramcore::SamRecord parsed;
-   const std::vector<std::string> records = {
-      "boundary\t65535\tchr1\t0\t255\t10M\t*\t0\t-2147483647\tACGT\tIIII"};
 
-   ASSERT_EQ(ParseSamRecords(records, &parsed), 1U);
+   ASSERT_EQ(ParseSamRecords({"boundary\t65535\tchr1\t0\t255\t10M\t*\t0\t-2147483647\tACGT\tIIII"},
+                             [&](const ramcore::SamRecord &record) { parsed = record; }),
+             1U);
    EXPECT_EQ(parsed.flag, 65535);
    EXPECT_EQ(parsed.pos, 0);
    EXPECT_EQ(parsed.mapq, 255);
@@ -443,6 +452,7 @@ TEST_F(ramcoreTest, SamParserParsesValidIntegerBoundaries)
    EXPECT_EQ(parsed.tlen, std::numeric_limits<int>::min() + 1);
 }
 
+// NOLINTNEXTLINE(misc-use-internal-linkage)
 TEST_F(ramcoreTest, InvalidChromosomeDoesNotPolluteFRefVec)
 {
    const char *samFile = "samexample.sam";

--- a/test/ramcoretests.cxx
+++ b/test/ramcoretests.cxx
@@ -27,6 +27,7 @@ class ramcoreTest : public ::testing::Test {
 protected:
    static constexpr const char *kParserTestFile = "test_sam_parser_validation.sam";
 
+   // NOLINTNEXTLINE(readability-convert-member-functions-to-static)
    void SetUp() override
    {
       GenerateSAMFile("samexample.sam", 100);
@@ -34,6 +35,7 @@ protected:
       std::remove("test_rntuple.root");
    }
 
+   // NOLINTNEXTLINE(readability-convert-member-functions-to-static)
    void TearDown() override
    {
       std::remove("test_ttree.root");
@@ -460,7 +462,8 @@ TEST_F(ramcoreTest, InvalidChromosomeDoesNotPolluteFRefVec)
 
    RAMNTupleConverter::ConvertSAMToRAMNTuple(samFile, rntupleFile);
 
-   size_t refsBefore = RAMNTupleRecord::GetRnameRefs()->Size();
+   size_t refsBefore = 0;
+   refsBefore = RAMNTupleRecord::GetRnameRefs()->Size();
 
    testing::internal::CaptureStdout();
    testing::internal::CaptureStderr();
@@ -468,7 +471,8 @@ TEST_F(ramcoreTest, InvalidChromosomeDoesNotPolluteFRefVec)
    testing::internal::GetCapturedStdout();
    testing::internal::GetCapturedStderr();
 
-   size_t refsAfter = RAMNTupleRecord::GetRnameRefs()->Size();
+   size_t refsAfter = 0;
+   refsAfter = RAMNTupleRecord::GetRnameRefs()->Size();
 
    EXPECT_EQ(refsBefore, refsAfter)
       << "Invalid chromosome 'chrINVALID' was inserted into fRefVec (regression of issue #23)";

--- a/test/ramcoretests.cxx
+++ b/test/ramcoretests.cxx
@@ -11,10 +11,13 @@
 #include <filesystem>
 #include <fstream>
 #include <iostream>
+#include <limits>
 #include <string>
+#include <vector>
 #include "../benchmark/generate_sam_benchmark.h"
 #include "../tools/ramview.cxx"
 #include "ramcore/RAMNTupleView.h"
+#include "ramcore/SamParser.h"
 #include "ramcore/SamToNTuple.h"
 #include "rntuple/RAMNTupleRecord.h"
 #include "ramcore/SamToTTree.h"
@@ -22,6 +25,8 @@ namespace {
 
 class ramcoreTest : public ::testing::Test {
 protected:
+    static constexpr const char *kParserTestFile = "test_sam_parser_validation.sam";
+
     void SetUp() override {
        GenerateSAMFile("samexample.sam", 100);
        std::remove("test_ttree.root");
@@ -32,8 +37,33 @@ protected:
         std::remove("test_ttree.root");
         std::remove("test_rntuple.root");
         std::remove("samexample.sam");
+        std::remove(kParserTestFile);
         RAMNTupleRecord::GetIndex()->Clear();
     }
+
+   size_t ParseSamRecords(const std::vector<std::string> &records, ramcore::SamRecord *last_record = nullptr)
+   {
+      {
+         std::ofstream sam(kParserTestFile);
+         sam << "@HD\tVN:1.6\n";
+         sam << "@SQ\tSN:chr1\tLN:1000\n";
+         for (const auto &record : records) {
+            sam << record << '\n';
+         }
+      }
+
+      size_t count = 0;
+      ramcore::SamParser parser;
+      const bool parsed = parser.ParseFile(kParserTestFile, [](const std::string &, const std::string &) {},
+                                           [&](const ramcore::SamRecord &record, size_t) {
+                                              ++count;
+                                              if (last_record)
+                                                 *last_record = record;
+                                           });
+
+      EXPECT_TRUE(parsed);
+      return count;
+   }
 };
 
 TEST_F(ramcoreTest, ConversionProducesEqualEntries) {
@@ -381,6 +411,58 @@ TEST_F(ramcoreTest, SmartIndexRespectsPositionInterval)
    EXPECT_EQ(far, 1) << "Distant read should be indexed via position interval";
 
    std::remove(customSam);
+   std::remove(rntupleFile);
+}
+
+TEST_F(ramcoreTest, SamParserRejectsMalformedIntegerFields)
+{
+   const std::vector<std::string> records = {
+      "bad_flag\tabc\tchr1\t100\t60\t10M\t*\t0\t0\tACGT\tIIII",
+      "bad_flag_space\t 1\tchr1\t100\t60\t10M\t*\t0\t0\tACGT\tIIII",
+      "bad_pos\t0\tchr1\t12x\t60\t10M\t*\t0\t0\tACGT\tIIII",
+      "bad_mapq\t0\tchr1\t100\t256\t10M\t*\t0\t0\tACGT\tIIII",
+      "bad_pnext\t0\tchr1\t100\t60\t10M\t*\t-1\t0\tACGT\tIIII",
+      "bad_tlen_min\t0\tchr1\t100\t60\t10M\t*\t0\t-2147483648\tACGT\tIIII",
+      "bad_tlen\t0\tchr1\t100\t60\t10M\t*\t0\t999999999999999999999\tACGT\tIIII",
+      "good\t0\tchr1\t200\t60\t10M\t*\t0\t0\tACGT\tIIII"};
+
+   EXPECT_EQ(ParseSamRecords(records), 1U);
+}
+
+TEST_F(ramcoreTest, SamParserParsesValidIntegerBoundaries)
+{
+   ramcore::SamRecord parsed;
+   const std::vector<std::string> records = {
+      "boundary\t65535\tchr1\t0\t255\t10M\t*\t0\t-2147483647\tACGT\tIIII"};
+
+   ASSERT_EQ(ParseSamRecords(records, &parsed), 1U);
+   EXPECT_EQ(parsed.flag, 65535);
+   EXPECT_EQ(parsed.pos, 0);
+   EXPECT_EQ(parsed.mapq, 255);
+   EXPECT_EQ(parsed.pnext, 0);
+   EXPECT_EQ(parsed.tlen, std::numeric_limits<int>::min() + 1);
+}
+
+TEST_F(ramcoreTest, InvalidChromosomeDoesNotPolluteFRefVec)
+{
+   const char *samFile = "samexample.sam";
+   const char *rntupleFile = "test_rntuple.root";
+
+   RAMNTupleConverter::ConvertSAMToRAMNTuple(samFile, rntupleFile);
+
+   size_t refsBefore = RAMNTupleRecord::GetRnameRefs()->Size();
+
+   testing::internal::CaptureStdout();
+   testing::internal::CaptureStderr();
+   RAMNTupleConverter::ViewRegion(rntupleFile, "chrINVALID:100-200");
+   testing::internal::GetCapturedStdout();
+   testing::internal::GetCapturedStderr();
+
+   size_t refsAfter = RAMNTupleRecord::GetRnameRefs()->Size();
+
+   EXPECT_EQ(refsBefore, refsAfter)
+      << "Invalid chromosome 'chrINVALID' was inserted into fRefVec (regression of issue #23)";
+
    std::remove(rntupleFile);
 }
 


### PR DESCRIPTION
Fixes two small, independently tested data-integrity bugs in SAM ingestion,
grouped to land together.

1. **SamParser silently corrupts integer fields.** `ParseLine()` used `atoi()` for
flag/pos/mapq/pnext/tlen, which returns 0 on bad input, writing zeros to the
RNTuple with no warning. Replaced with a validated `ParseInt()` (`strtol`-based)
that enforces per-field bounds, rejects junk/whitespace/overflow, and skips bad
records with a warning. TLEN floor is `INT_MIN + 1` per the SAM spec (excludes
−2³¹ to avoid mate-pair negation overflow).

2. **Invalid chromosome queries pollute fRefVec.** `ViewRegion()` used the mutating
`GetRefId()`, so querying an unknown chromosome inserted it into `fRefVec` and
corrupted the table for the session. Added a const `FindRefId()` that returns -1
on miss without inserting, and switched `ViewRegion()` to it.