### PR TITLE
Fix float tag precision.

### DIFF
--- a/src/ramcore/BamtoNTuple.cxx
+++ b/src/ramcore/BamtoNTuple.cxx
@@ -15,6 +15,7 @@
 
 #include <array>
 #include <cstdint>
+#include <cstdio>
 #include <cstring>
 #include <iostream>
 #include <memory>
@@ -135,7 +136,15 @@ std::vector<std::string> GetTags(const bam1_t *b)
       case 'f': {
          float v{};
          memcpy(&v, aux, sizeof(v));
-         tags.emplace_back(FormatTag(tag.data(), 'f', std::to_string(v)));
+         // Must match htslib's rendering exactly, or a converted record no
+         // longer compares equal to the BAM it came from. htslib formats
+         // float aux values with "%g" (6 significant digits, trailing zeros
+         // stripped, scientific notation where shorter); std::to_string uses
+         // "%f" and always emits 6 decimal places, turning htslib's
+         // "pa:f:0.862" into "pa:f:0.862000".
+         char buf[32];
+         std::snprintf(buf, sizeof(buf), "%g", static_cast<double>(v));
+         tags.emplace_back(FormatTag(tag.data(), 'f', buf));
          aux += sizeof(v);
          break;
       }


### PR DESCRIPTION
The pa:f float tag is being re-rendered with default %f (6 decimals) instead of preserving the source representation. RNTuple stores 3 extra characters per affected record so it inflates the size.

Fixes #63.