### PR TITLE
Fix data loss in parser, encoding, and region queries

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -35,7 +35,7 @@ jobs:
 
     - name: Install dependencies
       run: |
-        wget -O root.tar.gz https://root.cern/download/root_v6.38.06.Linux-ubuntu24.04-x86_64-gcc13.3.tar.gz
+        wget -O root.tar.gz https://github.com/root-project/root/releases/download/v6-38-06/root_v6.38.06.Linux-ubuntu24.04-x86_64-gcc13.3.tar.gz
         sudo tar -xzf root.tar.gz -C /opt/
         echo "/opt/root/bin" >> "$GITHUB_PATH"
         sudo apt-get update

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     
     - name: Install ROOT
       run: |
-        ROOT_URL="https://root.cern/download/root_v6.38.06.Linux-ubuntu24.04-x86_64-gcc13.3.tar.gz"
+        ROOT_URL="https://github.com/root-project/root/releases/download/v6-38-06/root_v6.38.06.Linux-ubuntu24.04-x86_64-gcc13.3.tar.gz"
         wget -O root.tar.gz $ROOT_URL
         tar -xzf root.tar.gz -C /opt/
         echo "/opt/root/bin" >> $GITHUB_PATH
@@ -59,7 +59,7 @@ jobs:
     
     - name: Install ROOT
       run: |
-        ROOT_URL="https://root.cern/download/root_v6.38.06.Linux-ubuntu24.04-x86_64-gcc13.3.tar.gz"
+        ROOT_URL="https://github.com/root-project/root/releases/download/v6-38-06/root_v6.38.06.Linux-ubuntu24.04-x86_64-gcc13.3.tar.gz"
         wget -O root.tar.gz $ROOT_URL
         tar -xzf root.tar.gz -C /opt/
         echo "/opt/root/bin" >> $GITHUB_PATH

--- a/.github/workflows/clang-tidy-review.yml
+++ b/.github/workflows/clang-tidy-review.yml
@@ -43,7 +43,7 @@ jobs:
           split_workflow: true
           config_file: .clang-tidy
           install_commands: |
-            wget -q -O root.tar.gz "https://root.cern/download/root_v6.38.06.Linux-ubuntu24.04-x86_64-gcc13.3.tar.gz" &&
+            wget -q -O root.tar.gz "https://github.com/root-project/root/releases/download/v6-38-06/root_v6.38.06.Linux-ubuntu24.04-x86_64-gcc13.3.tar.gz" &&
             tar -xzf root.tar.gz -C /opt/ &&
             rm root.tar.gz
           clang_tidy_args: >

--- a/inc/ramcore/SamParser.h
+++ b/inc/ramcore/SamParser.h
@@ -92,7 +92,6 @@ private:
     size_t records_processed_ = 0;
     
     bool ParseLine(char* line, SamRecord& record);
-    static constexpr int kMaxLineLength = 10240;
 };
 
 void StripCRLF(char* str);

--- a/inc/ramcore/SamParser.h
+++ b/inc/ramcore/SamParser.h
@@ -90,8 +90,8 @@ public:
 private:
     size_t lines_processed_ = 0;
     size_t records_processed_ = 0;
-    
-    bool ParseLine(char* line, SamRecord& record);
+
+    bool ParseLine(char *line, SamRecord &record);
 };
 
 void StripCRLF(char* str);

--- a/inc/rntuple/RAMNTupleRecord.h
+++ b/inc/rntuple/RAMNTupleRecord.h
@@ -152,6 +152,10 @@ public:
    static std::unique_ptr<RAMNTupleRefs> fgRnextRefs;
    static std::unique_ptr<RAMNTupleIndex> fgIndex;
 
+   /// Longest reference span of any alignment in the file, so a region query
+   /// knows how far before the region a read may start. 0 means unrecorded.
+   static uint32_t fgMaxRefSpan;
+
 public:
    RAMNTupleRecord();
    ~RAMNTupleRecord() = default;
@@ -194,12 +198,7 @@ public:
    const std::string &GetOPT(int idx) const { return tags[idx]; }
 
    // Return sequence length without decoding (fast)
-   int GetSEQLEN() const
-   {
-      if (seq.size() < 4)
-         return 0;
-      return *reinterpret_cast<const uint32_t *>(seq.data());
-   }
+   int GetSEQLEN() const;
 
    size_t GetNCIGAROP() const { return cigar.size(); }
    int32_t GetCIGAROPLEN(size_t idx) const;
@@ -212,6 +211,14 @@ public:
 
    // Static managers
    static void InitializeRefs();
+   static uint32_t GetMaxRefSpan() { return fgMaxRefSpan; }
+   static void NoteRefSpan(uint32_t span)
+   {
+      if (span > fgMaxRefSpan)
+         fgMaxRefSpan = span;
+   }
+   /// Reference bases covered by this record's CIGAR (0 when it has none).
+   uint32_t GetRefSpan() const;
    static RAMNTupleRefs *GetRnameRefs() { return fgRnameRefs.get(); }
    static RAMNTupleRefs *GetRnextRefs() { return fgRnextRefs.get(); }
    static RAMNTupleIndex *GetIndex() { return fgIndex.get(); }
@@ -244,11 +251,12 @@ private:
 // Sequence and Quality utilities
 namespace RAMNTupleUtils {
 std::string EncodeSequence(const std::string &seq);
-std::string DecodeSequence(const std::string &encoded_seq, size_t length);
+std::string DecodeSequence(const char *packed, size_t packed_size, size_t length);
 
 std::string EncodeQuality(const std::string &qual, uint32_t compression_flags);
 std::string DecodeQuality(const std::string &encoded_qual, uint32_t compression_flags);
 
+/// Returns an empty vector and logs an error if the CIGAR is malformed.
 std::vector<uint32_t> ParseCIGAR(const std::string &cigar_str);
 std::string FormatCIGAR(const std::vector<uint32_t> &cigar_ops);
 

--- a/src/ramcore/BamtoNTuple.cxx
+++ b/src/ramcore/BamtoNTuple.cxx
@@ -32,6 +32,9 @@ constexpr int64_t kMappedInterval = 100;
 std::string GetSeq(const bam1_t *b)
 {
    const int len = b->core.l_qseq;
+   // A BAM record with no sequence is SEQ "*" in SAM, not an empty column.
+   if (len <= 0)
+      return "*";
    const uint8_t *enc = bam_get_seq(b);
    std::string s(static_cast<std::size_t>(len), 'N');
    for (int i = 0; i < len; ++i)
@@ -42,6 +45,8 @@ std::string GetSeq(const bam1_t *b)
 std::string GetQual(const bam1_t *b)
 {
    const int len = b->core.l_qseq;
+   if (len <= 0)
+      return "*";
    const uint8_t *q = bam_get_qual(b);
    if (q == nullptr || q[0] == 0xff)
       return "*";
@@ -242,6 +247,7 @@ void bamtoramntuple(const char *bamfile, const char *treefile, bool index, bool 
 
    while (sam_read1(bamIn, hdr, rec) >= 0) {
       FillRecord(recordPtr.get(), rec, hdr, quality_policy);
+      RAMNTupleRecord::NoteRefSpan(recordPtr->GetRefSpan());
       writer->Fill(*entry);
 
       if (index && !(rec->core.flag & kUnmapped) && recordPtr->GetREFID() >= 0) {

--- a/src/ramcore/RAMNTupleView.cxx
+++ b/src/ramcore/RAMNTupleView.cxx
@@ -19,11 +19,6 @@
 
 namespace {
 
-constexpr int FLAG_UNMAPPED = 0x4;
-constexpr int FLAG_SECONDARY = 0x100;
-constexpr int FLAG_SUPPLEMENTARY = 0x800;
-constexpr int FLAG_FILTER = FLAG_UNMAPPED | FLAG_SECONDARY | FLAG_SUPPLEMENTARY;
-
 // Computes how many reference bases an alignment covers using CIGAR.
 //
 // CIGAR (Compact Idiosyncratic Gapped Alignment Report) describes how a read
@@ -51,7 +46,9 @@ int computeRefSpan(const std::vector<uint32_t> &cigarOps)
          span += static_cast<int>(op >> 4);
       }
    }
-   return span;
+   // A placed record with no CIGAR still occupies the base it sits on; htslib's
+   // bam_endpos says the same, so region queries agree with samtools.
+   return span > 0 ? span : 1;
 }
 
 int resolveRefId(const char *name)
@@ -74,8 +71,9 @@ bool parseRegion(const std::string &region, TString &rname, Int_t &start, Int_t 
    start = 0;
    end = std::numeric_limits<Int_t>::max() - 1;
 
-   // No colon means chromosome-only query e.g. "chr1"
-   const std::size_t colonPos = region.find(':');
+   // No colon means chromosome-only query e.g. "chr1". Split on the last colon:
+   // reference names may contain colons themselves (GRCh38 has "HLA-A*01:01:01:01").
+   const std::size_t colonPos = region.rfind(':');
    if (colonPos == std::string::npos) {
       rname = region;
       return true;
@@ -133,52 +131,64 @@ Long64_t ramntupleview(const char *file, const char *query, bool /*cache*/, bool
    }
 
    TString rname;
-   Int_t rs, re;
-   if (!parseRegion(region, rname, rs, re)) {
-      std::cerr << "Invalid region format. Use rname[:start[-end]]\n";
-      return 0;
-   }
+   Int_t rs = 0;
+   Int_t re = std::numeric_limits<Int_t>::max() - 1;
 
-   int refid = resolveRefId(rname.Data());
+   // Try the whole string as a reference name before reading its last colon as a
+   // coordinate separator, the same order samtools uses.
+   int refid = resolveRefId(region.c_str());
    if (refid < 0) {
-      std::cerr << "Reference '" << rname.Data() << "' not found\n";
-      return 0;
+      if (!parseRegion(region, rname, rs, re)) {
+         std::cerr << "Invalid region format. Use rname[:start[-end]]\n";
+         return 0;
+      }
+      refid = resolveRefId(rname.Data());
+      if (refid < 0) {
+         std::cerr << "Reference '" << rname.Data() << "' not found\n";
+         return 0;
+      }
    }
 
-   auto flagView = reader->GetView<uint16_t>("record.flag");
    auto refidView = reader->GetView<int32_t>("record.refid");
    auto posView = reader->GetView<int32_t>("record.pos");
    auto cigarView = reader->GetView<std::vector<uint32_t>>("record.cigar");
 
+   // The index entry at or before the region start is not enough on its own: a
+   // read beginning earlier can still reach into the region, and starting there
+   // would step over it. Backing off by the longest span in the file is exact.
+   // A file that does not record the span (0) is scanned from the reference's
+   // first entry instead.
    auto index = RAMNTupleRecord::GetIndex();
-   Long64_t start = (index && index->Size() > 0) ? index->GetRow(refid, rs) : 0;
-   if (start < 0)
-      start = 0;
+   Long64_t start = 0;
+   if (index && index->Size() > 0) {
+      const Int_t maxSpan = static_cast<Int_t>(RAMNTupleRecord::GetMaxRefSpan());
+      const Int_t seekPos = (maxSpan > 0 && rs > maxSpan) ? rs - maxSpan : 0;
+      start = index->GetRow(refid, seekPos);
+      if (start < 0)
+         start = 0;
+   }
 
    Long64_t count = 0;
    const Long64_t total = reader->GetNEntries();
 
    for (Long64_t i = start; i < total; i++) {
-      if (flagView(i) & FLAG_FILTER)
-         continue;
-
-      int curRef = refidView(i);
+      const int curRef = refidView(i);
       if (curRef < refid)
          continue;
       if (curRef > refid)
          break;
 
-      int pos = posView(i);
+      const int pos = posView(i);
+      // Coordinate-sorted, so nothing after this can start inside the region.
       if (pos > re)
          break;
 
-      // Overlap: read_end >= rs (pos <= re guaranteed by break above)
+      // pos <= re is guaranteed by the break above, so a read starting at or
+      // after rs overlaps without needing its span decoded.
       if (pos >= rs) {
          count++;
-      } else {
-         int readEnd = pos + computeRefSpan(cigarView(i)) - 1;
-         if (readEnd >= rs)
-            count++;
+      } else if (pos + computeRefSpan(cigarView(i)) - 1 >= rs) {
+         count++;
       }
    }
 

--- a/src/ramcore/RAMNTupleView.cxx
+++ b/src/ramcore/RAMNTupleView.cxx
@@ -179,17 +179,11 @@ Long64_t ramntupleview(const char *file, const char *query, bool /*cache*/, bool
          break;
 
       const int pos = posView(i);
-      // Coordinate-sorted, so nothing after this can start inside the region.
       if (pos > re)
          break;
 
-      // pos <= re is guaranteed by the break above, so a read starting at or
-      // after rs overlaps without needing its span decoded.
-      if (pos >= rs) {
+      if (pos >= rs || pos + computeRefSpan(cigarView(i)) - 1 >= rs)
          count++;
-      } else if (pos + computeRefSpan(cigarView(i)) - 1 >= rs) {
-         count++;
-      }
    }
 
    stopwatch.Print();

--- a/src/ramcore/SamParser.cxx
+++ b/src/ramcore/SamParser.cxx
@@ -92,7 +92,7 @@ bool SamParser::ParseFile(const char *filename, HeaderCallback header_cb, Record
 
       StripCRLF(line);
 
-      if (line[0] == '\0') { // blank line, not a record
+      if (line[0] == '\0') {
          continue;
       }
 
@@ -130,6 +130,8 @@ bool SamParser::ParseLine(char *line, SamRecord &record)
    int field_num = 0;
    char *cursor = line;
    bool last_field = false;
+   static const char *kMandatory[] = {"qname", "flag", "rname", "pos",  "mapq", "cigar",
+                                      "rnext", "pnext", "tlen", "seq", "qual"};
 
    // Split on TAB without collapsing runs of delimiters: "a\t\tb" is three
    // fields, the middle one empty. strtok() reported two and shifted every later
@@ -144,21 +146,17 @@ bool SamParser::ParseLine(char *line, SamRecord &record)
          last_field = true;
       }
 
+      if (field_num <= 10 && !RequireNonEmpty(token, kMandatory[field_num], lines_processed_)) {
+         return false;
+      }
+
       switch (field_num) {
-      case 0:
-         if (!RequireNonEmpty(token, "qname", lines_processed_))
-            return false;
-         record.qname = token;
-         break;
+      case 0: record.qname = token; break;
       case 1:
          if (!ParseInt(token, record.flag, "flag", lines_processed_, 0, std::numeric_limits<unsigned short>::max()))
             return false;
          break;
-      case 2:
-         if (!RequireNonEmpty(token, "rname", lines_processed_))
-            return false;
-         record.rname = token;
-         break;
+      case 2: record.rname = token; break;
       case 3:
          if (!ParseInt(token, record.pos, "pos", lines_processed_, 0, std::numeric_limits<int>::max()))
             return false;
@@ -167,16 +165,8 @@ bool SamParser::ParseLine(char *line, SamRecord &record)
          if (!ParseInt(token, record.mapq, "mapq", lines_processed_, 0, std::numeric_limits<unsigned char>::max()))
             return false;
          break;
-      case 5:
-         if (!RequireNonEmpty(token, "cigar", lines_processed_))
-            return false;
-         record.cigar = token;
-         break;
-      case 6:
-         if (!RequireNonEmpty(token, "rnext", lines_processed_))
-            return false;
-         record.rnext = token;
-         break;
+      case 5: record.cigar = token; break;
+      case 6: record.rnext = token; break;
       case 7:
          if (!ParseInt(token, record.pnext, "pnext", lines_processed_, 0, std::numeric_limits<int>::max()))
             return false;
@@ -186,16 +176,8 @@ bool SamParser::ParseLine(char *line, SamRecord &record)
                        std::numeric_limits<int>::max()))
             return false;
          break;
-      case 9:
-         if (!RequireNonEmpty(token, "seq", lines_processed_))
-            return false;
-         record.seq = token;
-         break;
-      case 10:
-         if (!RequireNonEmpty(token, "qual", lines_processed_))
-            return false;
-         record.qual = token;
-         break;
+      case 9: record.seq = token; break;
+      case 10: record.qual = token; break;
       default: record.optional_fields.push_back(token); break;
       }
 

--- a/src/ramcore/SamParser.cxx
+++ b/src/ramcore/SamParser.cxx
@@ -44,6 +44,18 @@ bool ParseInt(const char *value, int &out, const char *field_name, size_t line_n
    return true;
 }
 
+// Every mandatory column holds at least one character, so an empty one means the
+// line is malformed -- usually a stray tab shifting the later columns.
+bool RequireNonEmpty(const char *value, const char *field_name, size_t line_number)
+{
+   if (value && *value != '\0') {
+      return true;
+   }
+   std::cerr << "[SamParser] Warning: empty value for field '" << field_name << "' at line " << line_number
+             << "; record skipped.\n";
+   return false;
+}
+
 } // namespace
 
 // NOLINTNEXTLINE(misc-use-internal-linkage)
@@ -67,22 +79,31 @@ bool SamParser::ParseFile(const char *filename, HeaderCallback header_cb, Record
    lines_processed_ = 0;
    records_processed_ = 0;
 
-   char line[kMaxLineLength];
+   // getline() grows its buffer to fit the line. A fixed buffer splits longer
+   // records into fragments that then parse as separate malformed records, so
+   // the read is lost outright -- and PacBio/ONT lines routinely exceed 100 kB.
+   char *line = nullptr;
+   size_t capacity = 0;
+
    SamRecord record;
 
-   while (fgets(line, kMaxLineLength, fp)) {
+   while (getline(&line, &capacity, fp) != -1) {
       lines_processed_++;
+
+      StripCRLF(line);
+
+      if (line[0] == '\0') { // blank line, not a record
+         continue;
+      }
 
       if (line[0] == '@') {
          char *tab = strchr(line, '\t');
          if (tab) {
             *tab = '\0';
-            StripCRLF(tab + 1);
             if (header_cb) {
                header_cb(line, tab + 1);
             }
          } else {
-            StripCRLF(line);
             if (header_cb) {
                header_cb(line, "");
             }
@@ -99,6 +120,7 @@ bool SamParser::ParseFile(const char *filename, HeaderCallback header_cb, Record
       }
    }
 
+   free(line);
    fclose(fp);
    return true;
 }
@@ -106,16 +128,37 @@ bool SamParser::ParseFile(const char *filename, HeaderCallback header_cb, Record
 bool SamParser::ParseLine(char *line, SamRecord &record)
 {
    int field_num = 0;
-   char *token = strtok(line, "\t");
+   char *cursor = line;
+   bool last_field = false;
 
-   while (token) {
+   // Split on TAB without collapsing runs of delimiters: "a\t\tb" is three
+   // fields, the middle one empty. strtok() reported two and shifted every later
+   // column left, so QUAL would be read as SEQ.
+   while (!last_field) {
+      char *token = cursor;
+      char *tab = strchr(cursor, '\t');
+      if (tab) {
+         *tab = '\0';
+         cursor = tab + 1;
+      } else {
+         last_field = true;
+      }
+
       switch (field_num) {
-      case 0: record.qname = token; break;
+      case 0:
+         if (!RequireNonEmpty(token, "qname", lines_processed_))
+            return false;
+         record.qname = token;
+         break;
       case 1:
          if (!ParseInt(token, record.flag, "flag", lines_processed_, 0, std::numeric_limits<unsigned short>::max()))
             return false;
          break;
-      case 2: record.rname = token; break;
+      case 2:
+         if (!RequireNonEmpty(token, "rname", lines_processed_))
+            return false;
+         record.rname = token;
+         break;
       case 3:
          if (!ParseInt(token, record.pos, "pos", lines_processed_, 0, std::numeric_limits<int>::max()))
             return false;
@@ -124,8 +167,16 @@ bool SamParser::ParseLine(char *line, SamRecord &record)
          if (!ParseInt(token, record.mapq, "mapq", lines_processed_, 0, std::numeric_limits<unsigned char>::max()))
             return false;
          break;
-      case 5: record.cigar = token; break;
-      case 6: record.rnext = token; break;
+      case 5:
+         if (!RequireNonEmpty(token, "cigar", lines_processed_))
+            return false;
+         record.cigar = token;
+         break;
+      case 6:
+         if (!RequireNonEmpty(token, "rnext", lines_processed_))
+            return false;
+         record.rnext = token;
+         break;
       case 7:
          if (!ParseInt(token, record.pnext, "pnext", lines_processed_, 0, std::numeric_limits<int>::max()))
             return false;
@@ -135,22 +186,29 @@ bool SamParser::ParseLine(char *line, SamRecord &record)
                        std::numeric_limits<int>::max()))
             return false;
          break;
-      case 9: record.seq = token; break;
+      case 9:
+         if (!RequireNonEmpty(token, "seq", lines_processed_))
+            return false;
+         record.seq = token;
+         break;
       case 10:
-         StripCRLF(token);
+         if (!RequireNonEmpty(token, "qual", lines_processed_))
+            return false;
          record.qual = token;
          break;
-      default:
-         StripCRLF(token);
-         record.optional_fields.push_back(token);
-         break;
+      default: record.optional_fields.push_back(token); break;
       }
 
       field_num++;
-      token = strtok(nullptr, "\t");
    }
 
-   return field_num >= 11;
+   if (field_num < 11) {
+      std::cerr << "[SamParser] Warning: line " << lines_processed_ << " has " << field_num
+                << " fields, at least 11 are required; record skipped.\n";
+      return false;
+   }
+
+   return true;
 }
 
 } // namespace ramcore

--- a/src/ramcore/SamParser.cxx
+++ b/src/ramcore/SamParser.cxx
@@ -130,8 +130,8 @@ bool SamParser::ParseLine(char *line, SamRecord &record)
    int field_num = 0;
    char *cursor = line;
    bool last_field = false;
-   static const char *kMandatory[] = {"qname", "flag", "rname", "pos",  "mapq", "cigar",
-                                      "rnext", "pnext", "tlen", "seq", "qual"};
+   static const char *kMandatory[] = {"qname", "flag",  "rname", "pos", "mapq", "cigar",
+                                      "rnext", "pnext", "tlen",  "seq", "qual"};
 
    // Split on TAB without collapsing runs of delimiters: "a\t\tb" is three
    // fields, the middle one empty. strtok() reported two and shifted every later

--- a/src/ramcore/SamToNTuple.cxx
+++ b/src/ramcore/SamToNTuple.cxx
@@ -101,6 +101,7 @@ void samtoramntuple(const char *datafile,
           recordPtr->SetOPT(opt.c_str());
        }
 
+       RAMNTupleRecord::NoteRefSpan(recordPtr->GetRefSpan());
        writer->Fill(*defaultEntry);
 
        // Index building: create a sparse lookup table so region queries can jump

--- a/src/ramcore/SamToNTuple.cxx
+++ b/src/ramcore/SamToNTuple.cxx
@@ -249,6 +249,7 @@ void samtoramntuple_split_by_chromosome(const char *datafile, const char *output
 
             size_t start = ctx * records_per_context;
             size_t end = std::min(start + records_per_context, records.size());
+            uint32_t max_span = 0;
 
             for (size_t i = start; i < end; ++i) {
                const auto &sam_record = records[i];
@@ -266,6 +267,7 @@ void samtoramntuple_split_by_chromosome(const char *datafile, const char *output
                recordPtr->SetPOS(sam_record.pos);
                recordPtr->SetMAPQ(sam_record.mapq);
                recordPtr->SetCIGAR(sam_record.cigar.c_str());
+               max_span = std::max(max_span, recordPtr->GetRefSpan());
                recordPtr->SetPNEXT(sam_record.pnext);
                recordPtr->SetTLEN(sam_record.tlen);
                recordPtr->SetSEQ(sam_record.seq.c_str());
@@ -278,6 +280,9 @@ void samtoramntuple_split_by_chromosome(const char *datafile, const char *output
 
                fill_context->Fill(*entry);
             }
+
+            std::lock_guard<std::mutex> lock(record_mutex);
+            RAMNTupleRecord::NoteRefSpan(max_span);
          });
       }
 

--- a/src/rntuple/RAMNTupleRecord.cxx
+++ b/src/rntuple/RAMNTupleRecord.cxx
@@ -613,17 +613,20 @@ std::vector<uint32_t> ParseCIGAR(const std::string &cigar_str)
 
    uint64_t length = 0;
    bool have_length = false;
-   bool ok = true;
+
+   auto fail = [&]() {
+      ::Error("ParseCIGAR", "malformed CIGAR '%s'", cigar_str.c_str());
+      cigar_ops.clear();
+      return cigar_ops;
+   };
 
    for (char c : cigar_str) {
       if (c >= '0' && c <= '9') {
          length = length * 10 + static_cast<uint64_t>(c - '0');
          // Bounded here rather than by std::stoul, which threw std::out_of_range
          // on a long run of digits and took the whole conversion down with it.
-         if (length > kMaxCigarOpLen) {
-            ok = false;
-            break;
-         }
+         if (length > kMaxCigarOpLen)
+            return fail();
          have_length = true;
          continue;
       }
@@ -631,21 +634,16 @@ std::vector<uint32_t> ParseCIGAR(const std::string &cigar_str)
       const uint8_t op = kCigarToCode[static_cast<uint8_t>(c)];
       // An unrecognised operator used to index a zero-filled table and come back
       // as 0 -- 'M' -- so "10Q" was silently stored as ten matches.
-      if (op == kCigarCodeInvalid || !have_length) {
-         ok = false;
-         break;
-      }
+      if (op == kCigarCodeInvalid || !have_length)
+         return fail();
 
       cigar_ops.push_back((static_cast<uint32_t>(length) << 4) | op);
       length = 0;
       have_length = false;
    }
 
-   // Digits left over mean a length with no operator ("100M5").
-   if (!ok || have_length) {
-      ::Error("ParseCIGAR", "malformed CIGAR '%s'", cigar_str.c_str());
-      cigar_ops.clear();
-   }
+   if (have_length)
+      return fail();
    return cigar_ops;
 }
 

--- a/src/rntuple/RAMNTupleRecord.cxx
+++ b/src/rntuple/RAMNTupleRecord.cxx
@@ -18,6 +18,7 @@ using namespace ROOT;
 std::unique_ptr<RAMNTupleRefs> RAMNTupleRecord::fgRnameRefs = nullptr;
 std::unique_ptr<RAMNTupleRefs> RAMNTupleRecord::fgRnextRefs = nullptr;
 std::unique_ptr<RAMNTupleIndex> RAMNTupleRecord::fgIndex = nullptr;
+uint32_t RAMNTupleRecord::fgMaxRefSpan = 0;
 
 static const char *kCodeToSeq = "=ACMGRSVTWYHKDBN";
 static uint8_t kSeqToCode[256] = {0};
@@ -27,6 +28,35 @@ static bool kSeqTableInit = false;
 static const char *kCodeToCigar = "MIDNSHP=X";
 static uint8_t kCigarToCode[256] = {0};
 static bool kCigarTableInit = false;
+
+// Any byte that is not a base code maps here. 15 is 'N', as in htslib's
+// seq_nt16_table, so an unrepresentable base degrades to "unknown" rather than
+// to '=' ("identical to the reference").
+static constexpr uint8_t kSeqCodeUnknown = 15;
+
+// Marks a byte that is not one of MIDNSHP=X; 0 would look like a valid 'M'.
+static constexpr uint8_t kCigarCodeInvalid = 0xFF;
+
+// (length << 4) | opcode leaves 28 bits for the length.
+static constexpr uint32_t kMaxCigarOpLen = 0x0FFFFFFF;
+
+// The 4-byte length prefix of a packed sequence, stored little-endian so the
+// byte order is part of the format and reads need no aligned load.
+static void StoreLE32(char *dst, uint32_t value)
+{
+   dst[0] = static_cast<char>(value & 0xFF);
+   dst[1] = static_cast<char>((value >> 8) & 0xFF);
+   dst[2] = static_cast<char>((value >> 16) & 0xFF);
+   dst[3] = static_cast<char>((value >> 24) & 0xFF);
+}
+
+static uint32_t LoadLE32(const char *src)
+{
+   return static_cast<uint32_t>(static_cast<unsigned char>(src[0])) |
+          (static_cast<uint32_t>(static_cast<unsigned char>(src[1])) << 8) |
+          (static_cast<uint32_t>(static_cast<unsigned char>(src[2])) << 16) |
+          (static_cast<uint32_t>(static_cast<unsigned char>(src[3])) << 24);
+}
 
 // Illumina 8-level quality binning: maps Q0-40+ to 8 values (0,1,6,15,22,27,33,37,40)
 // Reduces quality data ~80% with minimal accuracy loss
@@ -181,6 +211,9 @@ void RAMNTupleRecord::InitializeRefs()
       fgRnextRefs = std::make_unique<RAMNTupleRefs>();
    if (!fgIndex)
       fgIndex = std::make_unique<RAMNTupleIndex>();
+   // Per-file, so a second conversion in the same process does not inherit the
+   // first file's span.
+   fgMaxRefSpan = 0;
 }
 
 std::unique_ptr<RNTupleReader> RAMNTupleRecord::OpenRAMFile(const std::string &filename, const std::string &ntupleName)
@@ -210,6 +243,7 @@ void RAMNTupleRecord::WriteAllRefs(TFile &file)
    auto metaModel = RNTupleModel::Create();
    auto rnameField = metaModel->MakeField<std::vector<std::string>>("rname_refs");
    auto rnextField = metaModel->MakeField<std::vector<std::string>>("rnext_refs");
+   auto spanField = metaModel->MakeField<uint32_t>("max_ref_span");
 
    RNTupleWriteOptions writeOptions;
    writeOptions.SetCompression(505);
@@ -219,8 +253,11 @@ void RAMNTupleRecord::WriteAllRefs(TFile &file)
    auto rnamePtr = metaEntry->GetPtr<std::vector<std::string>>("rname_refs");
    auto rnextPtr = metaEntry->GetPtr<std::vector<std::string>>("rnext_refs");
 
+   auto spanPtr = metaEntry->GetPtr<uint32_t>("max_ref_span");
+
    *rnamePtr = fgRnameRefs->GetRefs();
    *rnextPtr = fgRnextRefs->GetRefs();
+   *spanPtr = fgMaxRefSpan;
    metaWriter->Fill(*metaEntry);
 }
 
@@ -238,6 +275,15 @@ void RAMNTupleRecord::ReadAllRefs(const std::string &filename)
          for (const auto &ref : refs) {
             fgRnameRefs->AddRef(ref);
          }
+      } catch (...) {
+         // Field doesn't exist
+      }
+
+      // Absent in files written before the field existed; 0 means "unknown".
+      fgMaxRefSpan = 0;
+      try {
+         auto span_view = reader->GetView<uint32_t>("max_ref_span");
+         fgMaxRefSpan = span_view(0);
       } catch (...) {
          // Field doesn't exist
       }
@@ -318,6 +364,29 @@ std::string RAMNTupleRecord::GetRNEXT() const
    return fgRnextRefs->GetRefName(refnext);
 }
 
+uint32_t RAMNTupleRecord::GetRefSpan() const
+{
+   uint32_t span = 0;
+   for (uint32_t op : cigar) {
+      switch (op & 0xF) {
+      case RAM_CIGAR_M:
+      case RAM_CIGAR_D:
+      case RAM_CIGAR_N:
+      case RAM_CIGAR_EQUAL:
+      case RAM_CIGAR_X: span += (op >> 4); break;
+      default: break;
+      }
+   }
+   return span;
+}
+
+int RAMNTupleRecord::GetSEQLEN() const
+{
+   if (seq.size() < 4)
+      return 0;
+   return static_cast<int>(LoadLE32(seq.data()));
+}
+
 void RAMNTupleRecord::SetCIGAR(const std::string &cigar_str)
 {
    cigar = RAMNTupleUtils::ParseCIGAR(cigar_str);
@@ -335,10 +404,11 @@ void RAMNTupleRecord::SetSEQ(const std::string &seq_str)
 
 std::string RAMNTupleRecord::GetSEQ() const
 {
+   // Restores the "*" that EncodeSequence folded into an empty payload.
    if (seq.size() < 4)
-      return "";
-   uint32_t length = *reinterpret_cast<const uint32_t *>(seq.data());
-   return RAMNTupleUtils::DecodeSequence(seq.substr(4), length);
+      return "*";
+   const uint32_t length = LoadLE32(seq.data());
+   return RAMNTupleUtils::DecodeSequence(seq.data() + 4, seq.size() - 4, length);
 }
 
 void RAMNTupleRecord::SetQUAL(const std::string &qual_str)
@@ -401,17 +471,20 @@ namespace RAMNTupleUtils {
 void InitializeTables()
 {
    if (!kSeqTableInit) {
-      std::memset(kSeqToCode, 0, 256);
-      for (int i = 1; i < 16; i++) {
-         kSeqToCode[static_cast<uint8_t>(kCodeToSeq[i])] = i;
+      std::memset(kSeqToCode, kSeqCodeUnknown, 256);
+      for (int i = 0; i < 16; i++) {
+         const char base = kCodeToSeq[i];
+         kSeqToCode[static_cast<uint8_t>(base)] = static_cast<uint8_t>(i);
+         // SAM permits lowercase bases (SEQ is [A-Za-z=.]+).
+         kSeqToCode[static_cast<uint8_t>(std::tolower(static_cast<unsigned char>(base)))] = static_cast<uint8_t>(i);
       }
       kSeqTableInit = true;
    }
 
    if (!kCigarTableInit) {
-      std::memset(kCigarToCode, 0, 256);
+      std::memset(kCigarToCode, kCigarCodeInvalid, 256);
       for (int i = 0; i < 9; i++) {
-         kCigarToCode[static_cast<uint8_t>(kCodeToCigar[i])] = i;
+         kCigarToCode[static_cast<uint8_t>(kCodeToCigar[i])] = static_cast<uint8_t>(i);
       }
       kCigarTableInit = true;
    }
@@ -421,38 +494,56 @@ std::string EncodeSequence(const std::string &seq)
 {
    InitializeTables();
 
-   uint32_t length = seq.length();
-   size_t encoded_size = 4 + (length + 1) / 2;
+   // "*" is SAM's "sequence not stored" sentinel, not a one-base read. An empty
+   // packed string means "no sequence"; a genuinely empty SEQ still gets its
+   // 4-byte length prefix.
+   if (seq == "*") {
+      return {};
+   }
+
+   const uint32_t length = static_cast<uint32_t>(seq.length());
+   const size_t encoded_size = 4 + (static_cast<size_t>(length) + 1) / 2;
    std::string encoded;
    encoded.resize(encoded_size);
 
-   std::memcpy(&encoded[0], &length, 4);
+   StoreLE32(&encoded[0], length);
 
    size_t j = 4;
    for (size_t i = 0; i + 1 < length; i += 2) {
-      encoded[j++] = (kSeqToCode[static_cast<uint8_t>(seq[i])] << 4) | kSeqToCode[static_cast<uint8_t>(seq[i + 1])];
+      encoded[j++] = static_cast<char>((kSeqToCode[static_cast<uint8_t>(seq[i])] << 4) |
+                                       kSeqToCode[static_cast<uint8_t>(seq[i + 1])]);
    }
    if (length % 2) {
-      encoded[j] = kSeqToCode[static_cast<uint8_t>(seq[length - 1])] << 4;
+      encoded[j] = static_cast<char>(kSeqToCode[static_cast<uint8_t>(seq[length - 1])] << 4);
    }
 
    return encoded;
 }
 
-std::string DecodeSequence(const std::string &encoded_seq, size_t length)
+std::string DecodeSequence(const char *packed, size_t packed_size, size_t length)
 {
+   InitializeTables();
+
+   // A truncated payload would otherwise be read past its end and yield bases
+   // that were never stored.
+   const size_t needed = (length + 1) / 2;
+   if (packed == nullptr || packed_size < needed) {
+      ::Error("DecodeSequence", "packed sequence holds %zu bytes, %zu needed for %zu bases", packed_size, needed,
+              length);
+      return {};
+   }
+
    std::string seq;
    seq.resize(length);
 
-   size_t pairs = length / 2;
+   const size_t pairs = length / 2;
    for (size_t i = 0; i < pairs; i++) {
-      uint8_t byte = encoded_seq[i];
+      const uint8_t byte = static_cast<uint8_t>(packed[i]);
       seq[i * 2] = kCodeToSeq[byte >> 4];
       seq[i * 2 + 1] = kCodeToSeq[byte & 0xf];
    }
    if (length % 2) {
-      // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
-      seq[length - 1] = kCodeToSeq[static_cast<uint8_t>(encoded_seq[length / 2]) >> 4];
+      seq[length - 1] = kCodeToSeq[static_cast<uint8_t>(packed[length / 2]) >> 4];
    }
 
    return seq;
@@ -515,21 +606,46 @@ std::vector<uint32_t> ParseCIGAR(const std::string &cigar_str)
    InitializeTables();
 
    std::vector<uint32_t> cigar_ops;
-   std::string num_str;
+
+   // "*" (and an empty field) mean the alignment has no CIGAR.
+   if (cigar_str.empty() || cigar_str == "*")
+      return cigar_ops;
+
+   uint64_t length = 0;
+   bool have_length = false;
+   bool ok = true;
 
    for (char c : cigar_str) {
-      if (std::isdigit(c)) {
-         num_str += c;
-      } else if (kCigarToCode[static_cast<uint8_t>(c)] < 9) {
-         if (!num_str.empty()) {
-            uint32_t len = std::stoul(num_str);
-            uint8_t op = kCigarToCode[static_cast<uint8_t>(c)];
-            cigar_ops.push_back((len << 4) | op);
-            num_str.clear();
+      if (c >= '0' && c <= '9') {
+         length = length * 10 + static_cast<uint64_t>(c - '0');
+         // Bounded here rather than by std::stoul, which threw std::out_of_range
+         // on a long run of digits and took the whole conversion down with it.
+         if (length > kMaxCigarOpLen) {
+            ok = false;
+            break;
          }
+         have_length = true;
+         continue;
       }
+
+      const uint8_t op = kCigarToCode[static_cast<uint8_t>(c)];
+      // An unrecognised operator used to index a zero-filled table and come back
+      // as 0 -- 'M' -- so "10Q" was silently stored as ten matches.
+      if (op == kCigarCodeInvalid || !have_length) {
+         ok = false;
+         break;
+      }
+
+      cigar_ops.push_back((static_cast<uint32_t>(length) << 4) | op);
+      length = 0;
+      have_length = false;
    }
 
+   // Digits left over mean a length with no operator ("100M5").
+   if (!ok || have_length) {
+      ::Error("ParseCIGAR", "malformed CIGAR '%s'", cigar_str.c_str());
+      cigar_ops.clear();
+   }
    return cigar_ops;
 }
 

--- a/src/rntuple/RAMNTupleRecord.cxx
+++ b/src/rntuple/RAMNTupleRecord.cxx
@@ -13,6 +13,7 @@
 #include <fstream>
 #include <cstring>
 #include <cctype>
+#include <string_view>
 
 using namespace ROOT;
 
@@ -542,7 +543,7 @@ std::string DecodeSequence(const char *packed, size_t packed_size, size_t length
    std::string seq;
    seq.resize(length);
 
-   const std::string packed_bytes(packed, packed_size);
+   const std::string_view packed_bytes(packed, packed_size);
    const size_t pairs = length / 2;
    for (size_t i = 0; i < pairs; i++) {
       const uint8_t byte = static_cast<uint8_t>(packed_bytes[i]);
@@ -751,6 +752,7 @@ void RAMNTupleConverter::ConvertSAMToRAMNTuple(const std::string &sam_file, cons
          RAMNTupleRecord::GetIndex()->AddItem(rec.refid, rec.pos, entry_number);
       }
 
+      RAMNTupleRecord::NoteRefSpan(rec.GetRefSpan());
       *recordPtr = std::move(rec);
       writer->Fill(*defaultEntry);
 

--- a/src/rntuple/RAMNTupleRecord.cxx
+++ b/src/rntuple/RAMNTupleRecord.cxx
@@ -13,7 +13,6 @@
 #include <fstream>
 #include <cstring>
 #include <cctype>
-#include <string_view>
 
 using namespace ROOT;
 
@@ -526,6 +525,7 @@ std::string EncodeSequence(const std::string &seq)
    return encoded;
 }
 
+// NOLINTNEXTLINE(misc-use-internal-linkage) -- declared in RAMNTupleRecord.h
 std::string DecodeSequence(const char *packed, size_t packed_size, size_t length)
 {
    InitializeTables();
@@ -542,7 +542,7 @@ std::string DecodeSequence(const char *packed, size_t packed_size, size_t length
    std::string seq;
    seq.resize(length);
 
-   const std::string_view packed_bytes(packed, packed_size);
+   const std::string packed_bytes(packed, packed_size);
    const size_t pairs = length / 2;
    for (size_t i = 0; i < pairs; i++) {
       const uint8_t byte = static_cast<uint8_t>(packed_bytes[i]);

--- a/src/rntuple/RAMNTupleRecord.cxx
+++ b/src/rntuple/RAMNTupleRecord.cxx
@@ -7,11 +7,13 @@
 #include <TError.h>
 #include <TFile.h>
 #include <algorithm>
+#include <array>
 #include <sstream>
 #include <iostream>
 #include <fstream>
 #include <cstring>
 #include <cctype>
+#include <string_view>
 
 using namespace ROOT;
 
@@ -20,12 +22,13 @@ std::unique_ptr<RAMNTupleRefs> RAMNTupleRecord::fgRnextRefs = nullptr;
 std::unique_ptr<RAMNTupleIndex> RAMNTupleRecord::fgIndex = nullptr;
 uint32_t RAMNTupleRecord::fgMaxRefSpan = 0;
 
-static const char *kCodeToSeq = "=ACMGRSVTWYHKDBN";
+static constexpr std::array<char, 16> kCodeToSeq{'=', 'A', 'C', 'M', 'G', 'R', 'S', 'V',
+                                                 'T', 'W', 'Y', 'H', 'K', 'D', 'B', 'N'};
 static uint8_t kSeqToCode[256] = {0};
 static bool kSeqTableInit = false;
 
 // CIGAR encoding/decoding tables
-static const char *kCodeToCigar = "MIDNSHP=X";
+static constexpr std::array<char, 9> kCodeToCigar{'M', 'I', 'D', 'N', 'S', 'H', 'P', '=', 'X'};
 static uint8_t kCigarToCode[256] = {0};
 static bool kCigarTableInit = false;
 
@@ -44,18 +47,21 @@ static constexpr uint32_t kMaxCigarOpLen = 0x0FFFFFFF;
 // byte order is part of the format and reads need no aligned load.
 static void StoreLE32(char *dst, uint32_t value)
 {
-   dst[0] = static_cast<char>(value & 0xFF);
-   dst[1] = static_cast<char>((value >> 8) & 0xFF);
-   dst[2] = static_cast<char>((value >> 16) & 0xFF);
-   dst[3] = static_cast<char>((value >> 24) & 0xFF);
+   const std::array<unsigned char, 4> bytes{
+      static_cast<unsigned char>(value & 0xFF),
+      static_cast<unsigned char>((value >> 8) & 0xFF),
+      static_cast<unsigned char>((value >> 16) & 0xFF),
+      static_cast<unsigned char>((value >> 24) & 0xFF),
+   };
+   std::memcpy(dst, bytes.data(), bytes.size());
 }
 
 static uint32_t LoadLE32(const char *src)
 {
-   return static_cast<uint32_t>(static_cast<unsigned char>(src[0])) |
-          (static_cast<uint32_t>(static_cast<unsigned char>(src[1])) << 8) |
-          (static_cast<uint32_t>(static_cast<unsigned char>(src[2])) << 16) |
-          (static_cast<uint32_t>(static_cast<unsigned char>(src[3])) << 24);
+   std::array<unsigned char, 4> bytes{};
+   std::memcpy(bytes.data(), src, bytes.size());
+   return static_cast<uint32_t>(bytes[0]) | (static_cast<uint32_t>(bytes[1]) << 8) |
+          (static_cast<uint32_t>(bytes[2]) << 16) | (static_cast<uint32_t>(bytes[3]) << 24);
 }
 
 // Illumina 8-level quality binning: maps Q0-40+ to 8 values (0,1,6,15,22,27,33,37,40)
@@ -472,7 +478,7 @@ void InitializeTables()
 {
    if (!kSeqTableInit) {
       std::memset(kSeqToCode, kSeqCodeUnknown, 256);
-      for (int i = 0; i < 16; i++) {
+      for (size_t i = 0; i < kCodeToSeq.size(); i++) {
          const char base = kCodeToSeq[i];
          kSeqToCode[static_cast<uint8_t>(base)] = static_cast<uint8_t>(i);
          // SAM permits lowercase bases (SEQ is [A-Za-z=.]+).
@@ -483,7 +489,7 @@ void InitializeTables()
 
    if (!kCigarTableInit) {
       std::memset(kCigarToCode, kCigarCodeInvalid, 256);
-      for (int i = 0; i < 9; i++) {
+      for (size_t i = 0; i < kCodeToCigar.size(); i++) {
          kCigarToCode[static_cast<uint8_t>(kCodeToCigar[i])] = static_cast<uint8_t>(i);
       }
       kCigarTableInit = true;
@@ -502,7 +508,7 @@ std::string EncodeSequence(const std::string &seq)
    }
 
    const uint32_t length = static_cast<uint32_t>(seq.length());
-   const size_t encoded_size = 4 + (static_cast<size_t>(length) + 1) / 2;
+   const size_t encoded_size = 4 + ((static_cast<size_t>(length) + 1) / 2);
    std::string encoded;
    encoded.resize(encoded_size);
 
@@ -536,14 +542,15 @@ std::string DecodeSequence(const char *packed, size_t packed_size, size_t length
    std::string seq;
    seq.resize(length);
 
+   const std::string_view packed_bytes(packed, packed_size);
    const size_t pairs = length / 2;
    for (size_t i = 0; i < pairs; i++) {
-      const uint8_t byte = static_cast<uint8_t>(packed[i]);
+      const uint8_t byte = static_cast<uint8_t>(packed_bytes[i]);
       seq[i * 2] = kCodeToSeq[byte >> 4];
       seq[i * 2 + 1] = kCodeToSeq[byte & 0xf];
    }
    if (length % 2) {
-      seq[length - 1] = kCodeToSeq[static_cast<uint8_t>(packed[length / 2]) >> 4];
+      seq[length - 1] = kCodeToSeq[static_cast<uint8_t>(packed_bytes[length / 2]) >> 4];
    }
 
    return seq;

--- a/test/ramcoretests.cxx
+++ b/test/ramcoretests.cxx
@@ -194,26 +194,64 @@ TEST_F(ramcoreTest, RNTupleViewCigarOverlap)
    std::remove(rntupleFile);
 }
 
-TEST_F(ramcoreTest, RNTupleViewFlagFiltering)
+// `samtools view <region>` returns every alignment overlapping the region,
+// secondary and supplementary included -- they cover the locus as much as the
+// primary does. Silently returning a subset makes every count from this format
+// disagree with samtools.
+TEST_F(ramcoreTest, RegionQueryReturnsAllOverlappingAlignments)
 {
    const char *customSam = "test_flags.sam";
    const char *rntupleFile = "test_flags.root";
-   const std::string seq(50, 'A');
 
    {
       std::ofstream sam(customSam);
-      sam << "@HD\tVN:1.6\tSO:unsorted\n";
+      sam << "@HD\tVN:1.6\tSO:coordinate\n";
       sam << "@SQ\tSN:chr1\tLN:1000\n";
-      sam << "primary\t0\tchr1\t100\t60\t50M\t*\t0\t0\t" << seq << "\t*\n";
-      sam << "secondary\t256\tchr1\t100\t60\t50M\t*\t0\t0\t" << seq << "\t*\n";
-      sam << "supplementary\t2048\tchr1\t100\t60\t50M\t*\t0\t0\t" << seq << "\t*\n";
-      sam << "unmapped\t4\tchr1\t100\t0\t50M\t*\t0\t0\t" << seq << "\t*\n";
+      sam << "primary\t0\tchr1\t100\t60\t50M\t*\t0\t0\tACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTAC\t*\n";
+      sam << "unmapped\t4\tchr1\t100\t0\t*\t*\t0\t0\tACGTACGTAC\t*\n";
+      sam << "secondary\t256\tchr1\t150\t60\t50M\t*\t0\t0\tACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTAC\t*\n";
+      sam
+         << "supplementary\t2048\tchr1\t200\t60\t50M\t*\t0\t0\tACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTAC\t*\n";
    }
 
    samtoramntuple(customSam, rntupleFile, false, false, false, 505, 0);
 
-   Long64_t count = ramntupleview(rntupleFile, "chr1:1-500", true, false, nullptr);
-   EXPECT_EQ(count, 1) << "Only primary read should pass FLAG_FILTER";
+   EXPECT_EQ(ramntupleview(rntupleFile, "chr1:1-500", true, false, nullptr), 4)
+      << "every alignment placed over the region must be reported";
+
+   std::remove(customSam);
+   std::remove(rntupleFile);
+}
+
+// The index is sparse, so the entry at or before a region start only
+// approximates where the region's reads begin. A read starting earlier and
+// running long still overlaps; seeking straight to the anchor would step over
+// it. Long reads and spliced RNA-seq alignments make this routine.
+TEST_F(ramcoreTest, RegionQueryFindsReadsStartingBeforeTheIndexAnchor)
+{
+   const char *customSam = "test_span.sam";
+   const char *rntupleFile = "test_span.root";
+
+   {
+      std::ofstream sam(customSam);
+      sam << "@HD\tVN:1.6\tSO:coordinate\n";
+      sam << "@SQ\tSN:chr1\tLN:1000000\n";
+
+      // Starts at 1000 and reaches 201009 through a long intron.
+      sam << "spanning\t0\tchr1\t1000\t60\t10M199990N10M\t*\t0\t0\t" << std::string(20, 'A') << "\t*\n";
+
+      // Enough short reads to put index anchors between it and the query region.
+      const std::string seq(50, 'C');
+      for (int i = 0; i < 300; ++i) {
+         sam << "short" << i << "\t0\tchr1\t" << (150000 + i * 10) << "\t60\t50M\t*\t0\t0\t" << seq << "\t*\n";
+      }
+      sam << "inside\t0\tchr1\t160050\t60\t50M\t*\t0\t0\t" << seq << "\t*\n";
+   }
+
+   samtoramntuple(customSam, rntupleFile, /*index=*/true, false, false, 505, 0);
+
+   EXPECT_EQ(ramntupleview(rntupleFile, "chr1:160000-160100", true, false, nullptr), 2)
+      << "the spanning read overlaps the region and must not be skipped";
 
    std::remove(customSam);
    std::remove(rntupleFile);

--- a/test/ramcoretests.cxx
+++ b/test/ramcoretests.cxx
@@ -203,15 +203,16 @@ TEST_F(ramcoreTest, RegionQueryReturnsAllOverlappingAlignments)
    const char *customSam = "test_flags.sam";
    const char *rntupleFile = "test_flags.root";
 
+   const std::string seq(50, 'A');
+
    {
       std::ofstream sam(customSam);
       sam << "@HD\tVN:1.6\tSO:coordinate\n";
       sam << "@SQ\tSN:chr1\tLN:1000\n";
-      sam << "primary\t0\tchr1\t100\t60\t50M\t*\t0\t0\tACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTAC\t*\n";
-      sam << "unmapped\t4\tchr1\t100\t0\t*\t*\t0\t0\tACGTACGTAC\t*\n";
-      sam << "secondary\t256\tchr1\t150\t60\t50M\t*\t0\t0\tACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTAC\t*\n";
-      sam
-         << "supplementary\t2048\tchr1\t200\t60\t50M\t*\t0\t0\tACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTAC\t*\n";
+      sam << "primary\t0\tchr1\t100\t60\t50M\t*\t0\t0\t" << seq << "\t*\n";
+      sam << "unmapped\t4\tchr1\t100\t0\t*\t*\t0\t0\t" << std::string(10, 'A') << "\t*\n";
+      sam << "secondary\t256\tchr1\t150\t60\t50M\t*\t0\t0\t" << seq << "\t*\n";
+      sam << "supplementary\t2048\tchr1\t200\t60\t50M\t*\t0\t0\t" << seq << "\t*\n";
    }
 
    samtoramntuple(customSam, rntupleFile, false, false, false, 505, 0);

--- a/test/ramcoretests.cxx
+++ b/test/ramcoretests.cxx
@@ -238,20 +238,23 @@ TEST_F(ramcoreTest, RegionQueryFindsReadsStartingBeforeTheIndexAnchor)
       sam << "@HD\tVN:1.6\tSO:coordinate\n";
       sam << "@SQ\tSN:chr1\tLN:1000000\n";
 
-      // Starts at 1000 and reaches 201009 through a long intron.
-      sam << "spanning\t0\tchr1\t1000\t60\t10M199990N10M\t*\t0\t0\t" << std::string(20, 'A') << "\t*\n";
+      // Starts at 100000 and reaches 300009 through a long intron.
+      sam << "spanning\t0\tchr1\t100000\t60\t10M199990N10M\t*\t0\t0\t" << std::string(20, 'A') << "\t*\n";
 
       // Enough short reads to put index anchors between it and the query region.
       const std::string seq(50, 'C');
       for (int i = 0; i < 300; ++i) {
-         sam << "short" << i << "\t0\tchr1\t" << (150000 + i * 10) << "\t60\t50M\t*\t0\t0\t" << seq << "\t*\n";
+         sam << "short" << i << "\t0\tchr1\t" << (290000 + i * 10) << "\t60\t50M\t*\t0\t0\t" << seq << "\t*\n";
       }
-      sam << "inside\t0\tchr1\t160050\t60\t50M\t*\t0\t0\t" << seq << "\t*\n";
+      sam << "inside\t0\tchr1\t300050\t60\t50M\t*\t0\t0\t" << seq << "\t*\n";
+      // An anchor past the region, so the lookup lands on the anchor before the
+      // region instead of falling back to a scan from the first record.
+      sam << "after\t0\tchr1\t310000\t60\t50M\t*\t0\t0\t" << seq << "\t*\n";
    }
 
    samtoramntuple(customSam, rntupleFile, /*index=*/true, false, false, 505, 0);
 
-   EXPECT_EQ(ramntupleview(rntupleFile, "chr1:160000-160100", opts), 2)
+   EXPECT_EQ(ramntupleview(rntupleFile, "chr1:300000-300100", opts), 2)
       << "the spanning read overlaps the region and must not be skipped";
 
    std::remove(customSam);


### PR DESCRIPTION
Fixes several cases where a RAM file read back cleanly but did not match the input.

src/ramcore/SamParser.cxx
- Read lines with getline() instead of a fixed 10 kB fgets buffer; longer lines were split into fragments and lost.
- Replace strtok with a tab-exact tokenizer; consecutive tabs collapsed and shifted later fields. Empty mandatory fields and short lines are rejected with a warning.

inc/ramcore/SamParser.h
- Remove kMaxLineLength, no longer used.

src/rntuple/RAMNTupleRecord.cxx, inc/rntuple/RAMNTupleRecord.h
- Unknown and lowercase bases decoded as '=' (code 0); unknown now maps to 'N', lowercase folds to its base.
- Unknown CIGAR operators decoded as 'M' (code 0), so "10Q" became "10M"; now rejected along with trailing digits. Lengths over 28 bits are bounded instead of throwing from std::stoul.
- SEQ "*" and CIGAR "*" round-trip instead of being stored as one-base values.
- Sequence length prefix is written and read explicitly little-endian; DecodeSequence checks the payload size. Byte-identical on x86/ARM, existing files unaffected.
- Add max_ref_span to the metadata ntuple: the longest reference span of any record in the file, tracked via NoteRefSpan during writing. 0 in older files.

src/ramcore/RAMNTupleView.cxx
- Remove the flag filter; secondary, supplementary and placed-unmapped reads are counted, matching samtools view. Behavior change.
- Seek to (start - max_ref_span) instead of start, so reads beginning before the index anchor are not skipped. Files with max_ref_span = 0 scan from the reference start.
- Try the whole query as a reference name before splitting on the last colon, so names like HLA-A*01:01:01:01 resolve.
- Records with no CIGAR span one base, as in bam_endpos.

src/ramcore/BamtoNTuple.cxx, src/ramcore/SamToNTuple.cxx
- Call NoteRefSpan per record. BAM records with no sequence emit "*" instead of an empty column.

test/ramcoretests.cxx
- Replace RNTupleViewFlagFiltering with RegionQueryReturnsAllOverlappingAlignments.
- Add RegionQueryFindsReadsStartingBeforeTheIndexAnchor.

AI Usage:- I have used AI to write the code but reviewed it myself