### PR TITLE
Fix header storage and file-open time in the converters

### DIFF
--- a/inc/rntuple/LinkDef.h
+++ b/inc/rntuple/LinkDef.h
@@ -8,6 +8,13 @@
 
 #pragma link C++ class RAMNTupleRecord + ;
 #pragma link C++ class RAMNTupleIndex + ;
+// IndexEntry is stored in every RAM file, so ROOT needs a TClass for it on each
+// open. Without a dictionary entry cling parses the headers instead, which costs
+// about two seconds per open.
+// clang-format off
+#pragma link C++ class RAMNTupleIndex::IndexEntry + ;
+#pragma link C++ class std::vector<RAMNTupleIndex::IndexEntry> + ;
+// clang-format on
 
 #endif
 // NOLINTEND(llvm-header-guard)

--- a/src/ramcore/BamtoNTuple.cxx
+++ b/src/ramcore/BamtoNTuple.cxx
@@ -286,13 +286,17 @@ void bamtoramntuple(const char *bamfile, const char *treefile, bool index, bool 
       std::istringstream ss(text);
       std::string line;
       while (std::getline(ss, line)) {
-         if (line.size() >= 3) {
-            auto named_obj = std::make_unique<TNamed>(line.substr(0, 3).c_str(), line.c_str());
-            headers.Add(named_obj.release());
-         }
+         if (line.size() < 3)
+            continue;
+         // Same split as the SAM writer: the tag, then everything after the first tab.
+         const size_t tab = line.find('\t');
+         auto named_obj = std::make_unique<TNamed>(
+            line.substr(0, tab).c_str(), line.substr(tab == std::string::npos ? line.size() : tab + 1).c_str());
+         headers.Add(named_obj.release());
       }
    }
-   headers.Write();
+   // One key for the list; without kSingleKey every line is written as its own key.
+   headers.Write("headers", TObject::kSingleKey);
 
    rootFile->Close();
    sam_hdr_destroy(hdr);

--- a/src/ramcore/SamToNTuple.cxx
+++ b/src/ramcore/SamToNTuple.cxx
@@ -76,7 +76,7 @@ void samtoramntuple(const char *datafile,
                 size_t tab_pos = content.find('\t', sn_pos);
                 std::string ref_name =
                    content.substr(sn_pos, tab_pos != std::string::npos ? tab_pos - sn_pos : std::string::npos);
-                RAMNTupleRecord::GetRnameRefs()->GetRefId(ref_name.c_str());
+                RAMNTupleRecord::GetRnameRefs()->GetRefId(ref_name);
             }
         }
     };
@@ -84,21 +84,21 @@ void samtoramntuple(const char *datafile,
     auto record_callback = [&](const ramcore::SamRecord &sam_record, size_t record_num) {
        recordPtr->SetBit(quality_policy);
 
-       recordPtr->SetQNAME(sam_record.qname.c_str());
+       recordPtr->SetQNAME(sam_record.qname);
        recordPtr->SetFLAG(sam_record.flag);
-       recordPtr->SetREFID(sam_record.rname.c_str());
+       recordPtr->SetREFID(sam_record.rname);
        recordPtr->SetPOS(sam_record.pos);
        recordPtr->SetMAPQ(sam_record.mapq);
-       recordPtr->SetCIGAR(sam_record.cigar.c_str());
-       recordPtr->SetREFNEXT(sam_record.rnext.c_str());
+       recordPtr->SetCIGAR(sam_record.cigar);
+       recordPtr->SetREFNEXT(sam_record.rnext);
        recordPtr->SetPNEXT(sam_record.pnext);
        recordPtr->SetTLEN(sam_record.tlen);
-       recordPtr->SetSEQ(sam_record.seq.c_str());
-       recordPtr->SetQUAL(sam_record.qual.c_str());
+       recordPtr->SetSEQ(sam_record.seq);
+       recordPtr->SetQUAL(sam_record.qual);
 
        recordPtr->ResetNOPT();
        for (const auto &opt : sam_record.optional_fields) {
-          recordPtr->SetOPT(opt.c_str());
+          recordPtr->SetOPT(opt);
        }
 
        RAMNTupleRecord::NoteRefSpan(recordPtr->GetRefSpan());
@@ -190,7 +190,7 @@ void samtoramntuple_split_by_chromosome(const char *datafile, const char *output
             size_t tab_pos = content.find('\t', sn_pos);
             std::string ref_name =
                content.substr(sn_pos, tab_pos != std::string::npos ? tab_pos - sn_pos : std::string::npos);
-            RAMNTupleRecord::GetRnameRefs()->GetRefId(ref_name.c_str());
+            RAMNTupleRecord::GetRnameRefs()->GetRefId(ref_name);
          }
       }
    };
@@ -257,27 +257,27 @@ void samtoramntuple_split_by_chromosome(const char *datafile, const char *output
                const auto &sam_record = records[i];
 
                recordPtr->SetBit(quality_policy);
-               recordPtr->SetQNAME(sam_record.qname.c_str());
+               recordPtr->SetQNAME(sam_record.qname);
                recordPtr->SetFLAG(sam_record.flag);
 
                {
                   std::lock_guard<std::mutex> lock(record_mutex);
-                  recordPtr->SetREFID(sam_record.rname.c_str());
-                  recordPtr->SetREFNEXT(sam_record.rnext.c_str());
+                  recordPtr->SetREFID(sam_record.rname);
+                  recordPtr->SetREFNEXT(sam_record.rnext);
                }
 
                recordPtr->SetPOS(sam_record.pos);
                recordPtr->SetMAPQ(sam_record.mapq);
-               recordPtr->SetCIGAR(sam_record.cigar.c_str());
+               recordPtr->SetCIGAR(sam_record.cigar);
                max_span = std::max(max_span, recordPtr->GetRefSpan());
                recordPtr->SetPNEXT(sam_record.pnext);
                recordPtr->SetTLEN(sam_record.tlen);
-               recordPtr->SetSEQ(sam_record.seq.c_str());
-               recordPtr->SetQUAL(sam_record.qual.c_str());
+               recordPtr->SetSEQ(sam_record.seq);
+               recordPtr->SetQUAL(sam_record.qual);
 
                recordPtr->ResetNOPT();
                for (const auto &opt : sam_record.optional_fields) {
-                  recordPtr->SetOPT(opt.c_str());
+                  recordPtr->SetOPT(opt);
                }
 
                fill_context->Fill(*entry);

--- a/src/ramcore/SamToNTuple.cxx
+++ b/src/ramcore/SamToNTuple.cxx
@@ -148,7 +148,9 @@ void samtoramntuple(const char *datafile,
     }
     RAMNTupleRecord::WriteAllRefs(*rootFile);
 
-    headers.Write();
+    // One key for the list; without kSingleKey every line is written as its own
+    // key and no reader can get the header back in order.
+    headers.Write("headers", TObject::kSingleKey);
     rootFile->Close();
 
     printf("\nRAM file created: %s\n", treefile);
@@ -301,7 +303,7 @@ void samtoramntuple_split_by_chromosome(const char *datafile, const char *output
       }
 
       RAMNTupleRecord::WriteAllRefs(*file);
-      h.Write();
+      h.Write("headers", TObject::kSingleKey);
 
       file->Close();
    };


### PR DESCRIPTION
Three small fixes to the RNTuple writers.

- Generate a dictionary for RAMNTupleIndex::IndexEntry. The struct is stored in every RAM file, so ROOT builds a TClass for it on every open. Without a dictionary it falls back to parsing the headers through cling, which costs about two seconds per open. A region query on a 16 KB file drops from 2.5 s to 0.8 s; the rest is ROOT start-up.
- Write the SAM header as one key. TCollection::Write() without kSingleKey writes each element as its own key, so an 84-line header landed in the file as 84 keys all named "@SQ" and Get<TList>("headers") returned nothing. The BAM writer also stored the first three characters as the name and the whole line as the title, while the SAM writer stored the tag and the text after the first tab. Both now use the tag/content split. Files written before this change have no readable header; anything already converted needs converting again before ramdump (separate PR) can print its header.
 
- Stop building a `std::string from c_str()` for every field of every record in the SAM writer.
