### PR TITLE
Add -compression to the conversion tools and make the region benchmark reproducible

### DIFF
--- a/benchmark/region_query_benchmark.cxx
+++ b/benchmark/region_query_benchmark.cxx
@@ -2,15 +2,35 @@
 #include "benchmark_utils.h"
 #include "ramcore/RAMNTupleView.h"
 #include <string>
+#include <sstream>
 #include <cstdio>
 #include <cstdlib>
 #include <vector>
 #include <cstdint>
+#include <memory>
+#include <unistd.h>
 
-// File comes from the environment so the numbers are reproducible on any
-// machine. A hard-coded path is not a benchmark result.
+// File and regions come from the environment so the numbers are reproducible
+// on any machine. A hard-coded path is not a benchmark result.
 //
 //   RAMTOOLS_BENCH_RNTUPLE   RAM file written by samtoramntuple   (required)
+//   RAMTOOLS_BENCH_REGIONS   comma-separated regions to query     (optional)
+
+static std::vector<std::string> LoadRegions()
+{
+   const char *env = std::getenv("RAMTOOLS_BENCH_REGIONS");
+   std::stringstream spec((env && *env) ? env
+                                        : "chr1:1000000-1001000,chr1:1000000-2000000,chr1:1-50000000,chr21:1-48129895");
+   std::vector<std::string> regions;
+   std::string one{};
+   while (std::getline(spec, one, ','))
+      if (!one.empty())
+         regions.push_back(one);
+   return regions;
+}
+
+static const std::vector<std::string> kRegions = LoadRegions();
+
 class RegionQueryFixture : public benchmark::Fixture {
 public:
    void SetUp(const benchmark::State &state) override
@@ -26,32 +46,28 @@ protected:
    int region_idx_;
    std::string rntuple_root_file_;
 
-   static const std::vector<std::string> regions_;
+   // The query prints a summary per call. Reopening /dev/tty to undo the
+   // redirect fails whenever the output is piped, so the descriptor is saved.
+   void suppress_output()
+   {
+      fflush(stdout);
+      m_saved_stdout = dup(STDOUT_FILENO);
+      const std::unique_ptr<FILE, int (*)(FILE *)> null(fopen(NULL_DEVICE, "w"), fclose);
+      dup2(fileno(null.get()), STDOUT_FILENO);
+   }
 
-   void suppress_output() { freopen(NULL_DEVICE, "w", stdout); }
-   void restore_output() { freopen("/dev/tty", "w", stdout); }
+   void restore_output() const
+   {
+      fflush(stdout);
+      dup2(m_saved_stdout, STDOUT_FILENO);
+      close(m_saved_stdout);
+   }
 
-   const char *get_current_region() const { return regions_[region_idx_ % regions_.size()].c_str(); }
+   [[nodiscard]] const char *get_current_region() const { return kRegions[region_idx_].c_str(); }
+
+private:
+   int m_saved_stdout = -1;
 };
-
-const std::vector<std::string> RegionQueryFixture::regions_ = {"chr1:1000000-1001000",
-                                                               "chr2:5000000-5010000",
-                                                               "chrX:100000-150000",
-                                                               "chr1:1000000-2000000",
-                                                               "chr5:10000000-15000000",
-                                                               "chr10:50000000-60000000",
-                                                               "chr1:1-50000000",
-                                                               "chr2:1-100000000",
-                                                               "chr7:50000000-150000000",
-                                                               "chr21:1-48129895",
-                                                               "chrM:1-16571",
-                                                               "chrY:2600000-2700000",
-                                                               "GL000227.1:1-100000",
-                                                               "chr1:1-1000",
-                                                               "chr1:249250621-249250621",
-                                                               "chr22:51304566-51304566",
-                                                               "chr17:41196312-41277500",
-                                                               "chr13:32889611-32973805"};
 
 // NOLINTNEXTLINE(misc-use-internal-linkage)
 BENCHMARK_DEFINE_F(RegionQueryFixture, RNTuple)(benchmark::State &state)
@@ -75,10 +91,15 @@ BENCHMARK_DEFINE_F(RegionQueryFixture, RNTuple)(benchmark::State &state)
    }
 
    state.SetItemsProcessed(total_reads_processed);
-   state.counters["region_idx"] = region_idx_;
-   state.SetLabel(std::to_string(reads_in_this_run) + " reads");
+   state.SetLabel(std::string(region) + ": " + std::to_string(reads_in_this_run) + " reads");
 }
 
-BENCHMARK_REGISTER_F(RegionQueryFixture, RNTuple)->Args({0})->Args({3})->Args({6})->Args({9})->Unit(benchmark::kSecond);
+// One case per region. The cases used to be indices 0, 3, 6 and 9 into a
+// fixed list of eighteen.
+namespace {
+BENCHMARK_REGISTER_F(RegionQueryFixture, RNTuple)
+   ->DenseRange(0, static_cast<int>(kRegions.size()) - 1)
+   ->Unit(benchmark::kSecond);
+} // namespace
 
 BENCHMARK_MAIN();

--- a/src/ramcore/SamToNTuple.cxx
+++ b/src/ramcore/SamToNTuple.cxx
@@ -228,7 +228,7 @@ void samtoramntuple_split_by_chromosome(const char *datafile, const char *output
       auto model = RAMNTupleRecord::MakeModel();
       ROOT::RNTupleWriteOptions writeOptions;
 
-      writeOptions.SetCompression(ROOT::RCompressionSetting::EAlgorithm::kZSTD, 1);
+      writeOptions.SetCompression(compression_algorithm);
       writeOptions.SetApproxZippedClusterSize(200 * 1024 * 1024);
       writeOptions.SetMaxUnzippedClusterSize(1024 * 1024 * 1024);
       writeOptions.SetMaxUnzippedPageSize(1024 * 1024);

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -30,6 +30,13 @@ add_ramcore_test(ramcoretests ramcoretests.cxx)
 add_ramcore_test(chromosome_split_test chromosome_split_test.cxx)
 add_ramcore_test(bam_conversion bam_conversion.cxx)
 
+if(TARGET samtoramntuple)
+    add_test(NAME samtoramntuple_rejects_bad_compression COMMAND samtoramntuple in.sam -compression asd)
+    add_test(NAME bamtoramntuple_rejects_bad_compression COMMAND bamtoramntuple in.bam -compression 999)
+    set_tests_properties(samtoramntuple_rejects_bad_compression bamtoramntuple_rejects_bad_compression
+        PROPERTIES PASS_REGULAR_EXPRESSION "invalid -compression value")
+endif()
+
 install(TARGETS ramcoretests chromosome_split_test bam_conversion
     RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
 )

--- a/tools/bamtoramntuple.cxx
+++ b/tools/bamtoramntuple.cxx
@@ -3,8 +3,30 @@
 #include "rntuple/RAMNTupleRecord.h"
 
 #include <cstdint>
+#include <cstdlib>
 #include <iostream>
 #include <string>
+
+namespace {
+
+// ROOT compression code: algorithm*100+level, with algorithm 1 ZLIB, 2 LZMA,
+// 4 LZ4 or 5 ZSTD and level 1 to 9; 0 means no compression.
+bool ParseCompression(const std::string &text, int &code)
+{
+   char *end = nullptr;
+   const long value = std::strtol(text.c_str(), &end, 10);
+   if (text.empty() || *end != '\0' || value < 0)
+      return false;
+   const long algorithm = value / 100;
+   const long level = value % 100;
+   const bool known = algorithm == 1 || algorithm == 2 || algorithm == 4 || algorithm == 5;
+   if (value != 0 && (!known || level < 1 || level > 9))
+      return false;
+   code = static_cast<int>(value);
+   return true;
+}
+
+} // namespace
 
 int main(int argc, char *argv[])
 {
@@ -13,7 +35,8 @@ int main(int argc, char *argv[])
                 << "Options:\n"
                 << "  -noindex     Disable indexing\n"
                 << "  -illumina    Use Illumina quality binning\n"
-                << "  -dropqual    Drop quality scores\n";
+                << "  -dropqual    Drop quality scores\n"
+                << "  -compression N  ROOT compression code, algorithm*100+level (default 505, ZSTD level 5)\n";
       return 1;
    }
 
@@ -22,15 +45,29 @@ int main(int argc, char *argv[])
 
    bool do_index = true;
    uint32_t quality_mode = RAMNTupleRecord::kPhred33;
+   int compression = 505;
+   bool want_compression = false;
 
    for (int i = 2; i < argc; ++i) {
       const std::string arg = argv[i];
-      if (arg == "-noindex")
+      if (want_compression) {
+         if (!ParseCompression(arg, compression)) {
+            std::cerr << "invalid -compression value '" << arg << "'\n";
+            return 1;
+         }
+         want_compression = false;
+      } else if (arg == "-noindex")
          do_index = false;
       else if (arg == "-illumina" || arg == "-dropqual")
          quality_mode = (arg == "-illumina") ? RAMNTupleRecord::kIlluminaBinning : RAMNTupleRecord::kDrop;
+      else if (arg == "-compression")
+         want_compression = true;
       else if (arg[0] != '-')
          output = argv[i];
+   }
+   if (want_compression) {
+      std::cerr << "-compression needs a value\n";
+      return 1;
    }
 
    std::string outfile;
@@ -48,7 +85,7 @@ int main(int argc, char *argv[])
 
    bamtoramntuple(input, ramfile.c_str(),
                   /*index=*/do_index, /*split=*/false, /*cache=*/true,
-                  /*compression_algorithm=*/505, /*quality_policy=*/quality_mode);
+                  /*compression_algorithm=*/compression, /*quality_policy=*/quality_mode);
 
    return 0;
 }

--- a/tools/samtoramntuple.cxx
+++ b/tools/samtoramntuple.cxx
@@ -3,6 +3,28 @@
 #include <iostream>
 #include <string>
 #include <cstring>
+#include <cstdlib>
+
+namespace {
+
+// ROOT compression code: algorithm*100+level, with algorithm 1 ZLIB, 2 LZMA,
+// 4 LZ4 or 5 ZSTD and level 1 to 9; 0 means no compression.
+bool ParseCompression(const std::string &text, int &code)
+{
+   char *end = nullptr;
+   const long value = std::strtol(text.c_str(), &end, 10);
+   if (text.empty() || *end != '\0' || value < 0)
+      return false;
+   const long algorithm = value / 100;
+   const long level = value % 100;
+   const bool known = algorithm == 1 || algorithm == 2 || algorithm == 4 || algorithm == 5;
+   if (value != 0 && (!known || level < 1 || level > 9))
+      return false;
+   code = static_cast<int>(value);
+   return true;
+}
+
+} // namespace
 
 int main(int argc, char* argv[]) {
     if (argc < 2) {
@@ -12,6 +34,7 @@ int main(int argc, char* argv[]) {
        std::cout << "  -noindex     Disable indexing\n";
        std::cout << "  -illumina    Use Illumina quality binning\n";
        std::cout << "  -dropqual    Drop quality scores\n";
+       std::cout << "  -compression N  ROOT compression code, algorithm*100+level (default 505, ZSTD level 5)\n";
        return 1;
     }
     
@@ -21,10 +44,18 @@ int main(int argc, char* argv[]) {
     bool do_split = false;
     bool do_index = true;
     uint32_t quality_mode = RAMNTupleRecord::kPhred33;
-    
+    int compression = 505;
+    bool want_compression = false;
+
     for (int i = 2; i < argc; i++) {
         std::string arg = argv[i];
-        if (arg == "-split") {
+        if (want_compression) {
+           if (!ParseCompression(arg, compression)) {
+              std::cerr << "invalid -compression value '" << arg << "'\n";
+              return 1;
+           }
+           want_compression = false;
+        } else if (arg == "-split") {
            do_split = true;
         } else if (arg == "-noindex") {
            do_index = false;
@@ -32,9 +63,15 @@ int main(int argc, char* argv[]) {
            quality_mode = RAMNTupleRecord::kIlluminaBinning;
         } else if (arg == "-dropqual") {
            quality_mode = RAMNTupleRecord::kDrop;
+        } else if (arg == "-compression") {
+           want_compression = true;
         } else if (arg[0] != '-') {
            output = argv[i];
         }
+    }
+    if (want_compression) {
+       std::cerr << "-compression needs a value\n";
+       return 1;
     }
 
     std::string outfile;
@@ -49,13 +86,13 @@ int main(int argc, char* argv[]) {
 
     try {
        if (do_split) {
-          samtoramntuple_split_by_chromosome(input, output, 505, quality_mode, 4);
+          samtoramntuple_split_by_chromosome(input, output, compression, quality_mode, 4);
        } else {
           std::string ramfile = std::string(output);
           if (ramfile.find(".root") == std::string::npos && ramfile.find(".ram") == std::string::npos) {
              ramfile += ".ram";
           }
-          samtoramntuple(input, ramfile.c_str(), do_index, true, true, 505, quality_mode);
+          samtoramntuple(input, ramfile.c_str(), do_index, true, true, compression, quality_mode);
        }
     } catch (const std::exception& e) {
         std::cerr << "Error: " << e.what() << std::endl;


### PR DESCRIPTION
- samtoramntuple and bamtoramntuple pinned the output to ZSTD level 5. Both now take -compression N, the ROOT compression code (algorithm*100+level: 505 is ZSTD-5, 404 LZ4-4, 101 ZLIB-1, 207 LZMA-7), so files can be built at any setting for comparison. The split writer ignored the setting it was given and always used ZSTD level 1; it now uses the one passed in. This is the same problem as #49; the WIP in #50 takes a different CLI shape, so this may need reconciling with it.
- The region benchmark already took its file from RAMTOOLS_BENCH_RNTUPLE, but the regions were a fixed list of eighteen for one particular genome, of which indices 0, 3, 6 and 9 were measured. They now come from RAMTOOLS_BENCH_REGIONS, one case per region. restore_output() reopened /dev/tty, which fails whenever the output is piped or the benchmark runs in CI; it saves and restores the file descriptor instead.
- Verified: -compression 101, 505, 207 and 0 produce different file sizes; a missing value is reported; the benchmark skips with a message when the env is unset and runs with its output piped.