### PR TITLE
Reject malformed CIGAR strings in the SAM parser.

### DIFF
--- a/src/ramcore/SamParser.cxx
+++ b/src/ramcore/SamParser.cxx
@@ -2,10 +2,12 @@
 #include <cctype>
 #include <cerrno>
 #include <cstddef>
+#include <cstdint>
 #include <cstdlib>
 #include <cstring>
 #include <iostream>
 #include <limits>
+#include <string>
 
 namespace ramcore {
 
@@ -54,6 +56,29 @@ bool RequireNonEmpty(const char *value, const char *field_name, size_t line_numb
    std::cerr << "[SamParser] Warning: empty value for field '" << field_name << "' at line " << line_number
              << "; record skipped.\n";
    return false;
+}
+
+// A CIGAR is "*" or a run of <length><op> pairs. A malformed one used to reach
+// the record encoder, which stored the read with no CIGAR at all.
+bool ValidCigar(const std::string &cigar, size_t line_number)
+{
+   constexpr uint32_t kMaxOpLength = 0x0FFFFFFF; // 28 bits, as in BAM
+   bool ok = !cigar.empty();
+   size_t i = 0;
+   while (ok && i < cigar.size() && cigar != "*") {
+      uint32_t length = 0;
+      size_t digits = 0;
+      for (; i < cigar.size() && std::isdigit(static_cast<unsigned char>(cigar[i])); i++, digits++)
+         length = length * 10 + static_cast<uint32_t>(cigar[i] - '0');
+      ok = digits > 0 && digits <= 9 && length <= kMaxOpLength && i < cigar.size() &&
+           std::strchr("MIDNSHP=X", cigar[i]) != nullptr;
+      i++;
+   }
+   if (!ok) {
+      std::cerr << "[SamParser] Warning: malformed CIGAR '" << cigar << "' at line " << line_number
+                << "; record skipped.\n";
+   }
+   return ok;
 }
 
 } // namespace
@@ -165,7 +190,11 @@ bool SamParser::ParseLine(char *line, SamRecord &record)
          if (!ParseInt(token, record.mapq, "mapq", lines_processed_, 0, std::numeric_limits<unsigned char>::max()))
             return false;
          break;
-      case 5: record.cigar = token; break;
+      case 5:
+         record.cigar = token;
+         if (!ValidCigar(record.cigar, lines_processed_))
+            return false;
+         break;
       case 6: record.rnext = token; break;
       case 7:
          if (!ParseInt(token, record.pnext, "pnext", lines_processed_, 0, std::numeric_limits<int>::max()))

--- a/test/ramcoretests.cxx
+++ b/test/ramcoretests.cxx
@@ -530,6 +530,64 @@ TEST_F(ramcoreTest, SamParserRejectsMalformedIntegerFields)
 }
 
 // NOLINTNEXTLINE(misc-use-internal-linkage)
+TEST_F(ramcoreTest, SamParserRejectsMalformedCigar)
+{
+   // An unknown operator, no length, a trailing length, a length past BAM's
+   // 28-bit limit, a fractional length, and a second operator with no length.
+   for (const char *cigar : {"10Q", "M", "4M2", "268435456M", "1.5M", "4MI"}) {
+      const std::string record = std::string("r\t0\tchr1\t100\t60\t") + cigar + "\t*\t0\t0\tACGT\tIIII";
+      testing::internal::CaptureStderr();
+      EXPECT_EQ(ParseSamRecords({record.c_str()}), 0U) << "CIGAR '" << cigar << "' was accepted";
+      EXPECT_NE(testing::internal::GetCapturedStderr().find("malformed CIGAR"), std::string::npos)
+         << "no warning for CIGAR '" << cigar << "'";
+   }
+}
+
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+TEST_F(ramcoreTest, SamParserKeepsValidCigar)
+{
+   for (const char *cigar : {"*", "4M", "2S4M1I3M1D2N5=1X2H", "268435455M"}) {
+      const std::string record = std::string("r\t0\tchr1\t100\t60\t") + cigar + "\t*\t0\t0\tACGT\tIIII";
+      std::string seen;
+      EXPECT_EQ(ParseSamRecords({record.c_str()}, [&](const ramcore::SamRecord &r) { seen = r.cigar; }), 1U)
+         << "CIGAR '" << cigar << "' was rejected";
+      EXPECT_EQ(seen, cigar);
+   }
+}
+
+// A rejected record must not reach the file, and the records around it must.
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+TEST_F(ramcoreTest, MalformedCigarRecordIsSkippedByConversion)
+{
+   const char *samFile = "test_bad_cigar.sam";
+   const char *rntupleFile = "test_bad_cigar.root";
+   {
+      std::ofstream sam(samFile);
+      sam << "@HD\tVN:1.6\tSO:coordinate\n";
+      sam << "@SQ\tSN:chr1\tLN:1000\n";
+      sam << "a\t0\tchr1\t100\t60\t4M\t*\t0\t0\tACGT\tIIII\n";
+      sam << "b\t0\tchr1\t200\t60\t4Q\t*\t0\t0\tACGT\tIIII\n";
+      sam << "c\t0\tchr1\t300\t60\t2M2I\t*\t0\t0\tACGT\tIIII\n";
+   }
+
+   testing::internal::CaptureStderr();
+   samtoramntuple(samFile, rntupleFile, /*index=*/true, false, false, 505, 0);
+   EXPECT_NE(testing::internal::GetCapturedStderr().find("malformed CIGAR '4Q' at line 4"), std::string::npos);
+
+   auto reader = RAMNTupleRecord::OpenRAMFile(rntupleFile);
+   ASSERT_NE(reader, nullptr);
+   ASSERT_EQ(reader->GetNEntries(), 2U);
+   auto view = reader->GetView<RAMNTupleRecord>("record");
+   EXPECT_EQ(view(0).GetQNAME(), "a");
+   EXPECT_EQ(view(0).GetCIGAR(), "4M");
+   EXPECT_EQ(view(1).GetQNAME(), "c");
+   EXPECT_EQ(view(1).GetCIGAR(), "2M2I");
+
+   std::remove(samFile);
+   std::remove(rntupleFile);
+}
+
+// NOLINTNEXTLINE(misc-use-internal-linkage)
 TEST_F(ramcoreTest, SamParserParsesValidIntegerBoundaries)
 {
    ramcore::SamRecord parsed;


### PR DESCRIPTION
ParseCIGAR returns an empty vector for a string it cannot parse, and no caller checked, so a mapped read with a CIGAR like "10Q" was written with no CIGAR at all and read back as "*". The parser now validates the field the way it validates the integer fields: "*" or a run of <length><op> pairs with the operators MIDNSHP=X and lengths within BAM's 28-bit limit. A bad record is reported with its line number and skipped.