### PR TITLE
Bump ROOT version to 6.38, from 6.26

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,7 +24,7 @@ if(ENABLE_COVERAGE)
     endif()
 endif()
 
-set(ROOT_MIN_VERSION 6.26)
+set(ROOT_MIN_VERSION 6.38)
 find_package(ROOT ${ROOT_MIN_VERSION} REQUIRED COMPONENTS Core RIO ROOTNTuple ROOTNTupleUtil)
 
 include(${ROOT_USE_FILE})

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ RAMTools provides efficient tools for converting SAM files to ROOT's modern, col
 
 ## Requirements
 
-- ROOT 6.26+
+- ROOT 6.38+
 - C++17 compatible compiler
 - CMake 3.16+
 


### PR DESCRIPTION
`src/ramcore/SamToNTuple.cxx:236` calls `ROOT::RNTupleParallelWriter::Recreate(...)`

The CI uses the latest ROOT version (6.38), but the `CMakeLists.txt` itself still uses the older ROOT version (6.26).
The CI will pass its checks, but building the project itself from the repository alone would cause errors.

This PR just bumps up the ROOT version.