### PR TITLE
Give the clang-tidy review job a compile database.

### DIFF
--- a/.github/workflows/clang-tidy-review.yml
+++ b/.github/workflows/clang-tidy-review.yml
@@ -39,7 +39,7 @@ jobs:
         id: review
         with:
           build_dir: build
-          apt_packages: cmake,libxml2,libxml2-dev,libtinfo-dev,zlib1g-dev,libzstd-dev,libvdt-dev,libtbb-dev,libhts-dev,wget
+          apt_packages: cmake,libxml2,libxml2-dev,libtinfo-dev,zlib1g-dev,libzstd-dev,libvdt-dev,libtbb-dev,libhts-dev,libomp-dev,wget
           split_workflow: true
           config_file: .clang-tidy
           install_commands: |
@@ -47,10 +47,10 @@ jobs:
             tar -xzf root.tar.gz -C /opt/ &&
             rm root.tar.gz
           clang_tidy_args: >
-            --extra-arg=-I${{ github.workspace }}/inc
+            --extra-arg=-I/github/workspace/inc
             --extra-arg=-I/opt/root/include
-            --extra-arg=-I${{ github.workspace }}/build/test/googletest-prefix/src/googletest/googletest/include
-            --extra-arg=-I${{ github.workspace }}/build/benchmark/googlebenchmark-prefix/src/googlebenchmark/include
+            --extra-arg=-I/github/workspace/build/test/googletest-prefix/src/googletest/googletest/include
+            --extra-arg=-I/github/workspace/build/benchmark/googlebenchmark-prefix/src/googlebenchmark/include
           cmake_command: >
             bash -x -c '
             source /opt/root/bin/thisroot.sh &&


### PR DESCRIPTION
ROOTConfig.cmake calls find_dependency(OpenMP). The review job configures with the clang it downloads, which has no OpenMP runtime, so find_package(ROOT) fails, cmake writes no compile_commands.json, and clang-tidy runs with no include paths: every ROOT, gtest and project header is "not found", std::string is an unknown type, and the job posts findings like "std::string is not initialized" and "namespace ROOT is a non-const global" on every PR (see #70, #71, #73, #75). libomp-dev supplies the runtime. The extra include arguments also named the runner's workspace; the action runs in a container where the checkout is /github/workspace.