### PR TITLE
Record file order, stream the chromosome split, and index split files

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ cmake ..
 make -j$(nproc)
 
 # 2. Convert a SAM file to the RAM format
-./tools/samtoramntuple ../test/samexample.sam output.root
+./tools/samtoramntuple input.sam output.root
 
 # 3. Query a specific region from the command line
 ./tools/ramntupleview output.root "chr1:15700-15800"
@@ -40,13 +40,16 @@ Convert a standard SAM file into the optimized RNTuple-based RAM format.
 ./tools/samtoramntuple input.sam output.root
 
 # Split by chromosome for parallel processing
-# (Creates output-chr1.root, output-chr2.root, etc.)
+# (Creates output_chr1.root, output_chr2.root, etc.)
 ./tools/samtoramntuple input.sam output -split
 ```
 
+Options: `-noindex` skips the region index, `-illumina` stores 8-level binned
+quality scores, `-dropqual` stores none.
+
 ### Region Querying
 
-Query a specific genomic region from a RAM file, similar to samtools view.
+Count the records overlapping a genomic region, as `samtools view -c` does.
 ```bash
 # Usage: ./tools/ramntupleview [input.root] "[chromosome]:[start]-[end]"
 ./tools/ramntupleview output.root "chr1:10150-10300"

--- a/README.md
+++ b/README.md
@@ -45,7 +45,11 @@ Convert a standard SAM file into the optimized RNTuple-based RAM format.
 ```
 
 Options: `-noindex` skips the region index, `-illumina` stores 8-level binned
-quality scores, `-dropqual` stores none.
+quality scores, `-dropqual` stores none, `-compression N` sets the ROOT
+compression code (algorithm*100+level; the default 505 is ZSTD level 5).
+
+The index needs the input in coordinate order. An unsorted input converts
+fine but gets no index, and region queries on it read the whole file.
 
 ### Region Querying
 
@@ -53,6 +57,19 @@ Count the records overlapping a genomic region, as `samtools view -c` does.
 ```bash
 # Usage: ./tools/ramntupleview [input.root] "[chromosome]:[start]-[end]"
 ./tools/ramntupleview output.root "chr1:10150-10300"
+```
+
+### Dumping back to SAM
+
+`ramdump` writes a RAM file out as SAM and takes the `samtools view` options
+`-h`, `-H`, `-c`, `-f`, `-F` and `-o`, so its output can be checked against
+samtools directly.
+```bash
+# The whole file with its header; should reproduce the input SAM
+./tools/ramdump -h output.root > roundtrip.sam
+
+# Count primary alignments in a region
+./tools/ramdump -c -F 0x900 output.root "chr1:10150-10300"
 ```
 
 ## Benchmark Results

--- a/benchmark/chromosome_split_benchmark.cxx
+++ b/benchmark/chromosome_split_benchmark.cxx
@@ -137,10 +137,9 @@ static void BM_SamtoolsSplitThreaded(benchmark::State &state)
    state.counters["reads/s"] = benchmark::Counter(num_reads, benchmark::Counter::kIsRate);
 }
 
-static void BM_ChromosomeSplitThreads(benchmark::State &state)
+static void BM_ChromosomeSplit(benchmark::State &state)
 {
    int num_reads = state.range(0);
-   int num_threads = state.range(1);
    std::string sam_file = "bench_split_par_" + std::to_string(num_reads) + ".sam";
 
    GenerateSAMFile(sam_file, num_reads);
@@ -152,7 +151,7 @@ static void BM_ChromosomeSplitThreads(benchmark::State &state)
       stdout = fopen("/dev/null", "w");
       stderr = fopen("/dev/null", "w");
 
-      samtoramntuple_split_by_chromosome(sam_file.c_str(), "bench_split_par_out", 505, 1, num_threads);
+      samtoramntuple_split_by_chromosome(sam_file.c_str(), "bench_split_par_out", 505, 1);
 
       fclose(stdout);
       fclose(stderr);
@@ -160,7 +159,6 @@ static void BM_ChromosomeSplitThreads(benchmark::State &state)
       stderr = old_stderr;
 
       state.counters["size_MB"] = GetTotalFileSize("bench_split_par_out_") / (1024.0 * 1024.0);
-      state.counters["threads"] = num_threads;
       CleanupFiles("bench_split_par_out_");
    }
 
@@ -179,13 +177,6 @@ BENCHMARK(BM_SamtoolsSplitThreaded)
    ->Args({1000000, 4})
    ->Unit(benchmark::kMillisecond);
 
-BENCHMARK(BM_ChromosomeSplitThreads)
-   ->Args({100000, 2})
-   ->Args({100000, 4})
-   ->Args({500000, 2})
-   ->Args({500000, 4})
-   ->Args({1000000, 2})
-   ->Args({1000000, 4})
-   ->Unit(benchmark::kMillisecond);
+BENCHMARK(BM_ChromosomeSplit)->Arg(100000)->Arg(500000)->Arg(1000000)->Unit(benchmark::kMillisecond);
 
 BENCHMARK_MAIN();

--- a/inc/ramcore/SamToNTuple.h
+++ b/inc/ramcore/SamToNTuple.h
@@ -10,7 +10,9 @@ void samtoramntuple(const char *datafile,
                     int compression_algorithm,
                     uint32_t quality_policy);
 
+/// Writes one RAM file per reference, named <output_prefix>_<rname>.root.
+/// Records stream to their file as they are parsed, in the order they arrive.
 void samtoramntuple_split_by_chromosome(const char *datafile, const char *output_prefix, int compression_algorithm,
-                                        uint32_t quality_policy, int num_threads = 4);
+                                        uint32_t quality_policy);
 
 #endif

--- a/inc/rntuple/RAMNTupleRecord.h
+++ b/inc/rntuple/RAMNTupleRecord.h
@@ -225,6 +225,7 @@ public:
          fgMaxRefSpan = span;
    }
    static bool IsCoordinateSorted() { return fgCoordinateSorted; }
+   static void SetCoordinateSorted(bool sorted) { fgCoordinateSorted = sorted; }
    /// Feeds one placed record to the running order check.
    static void NotePlacement(int32_t refid_, int32_t pos_)
    {
@@ -245,6 +246,7 @@ public:
    static void WriteAllRefs(TFile &file);
    static void ReadAllRefs(const std::string &filename = "");
    static void WriteIndex(TFile &file);
+   static void WriteIndex(TFile &file, const RAMNTupleIndex &index);
    static void ReadIndex(const std::string &filename = "");
 
    // RNTuple model creation

--- a/inc/rntuple/RAMNTupleRecord.h
+++ b/inc/rntuple/RAMNTupleRecord.h
@@ -155,6 +155,14 @@ public:
    /// knows how far before the region a read may start. 0 means unrecorded.
    static uint32_t fgMaxRefSpan;
 
+   /// Whether the records are in coordinate order. A region query can only
+   /// seek to an index entry and stop at the first record past the region when
+   /// they are; on an unsorted file it reads every record. Files written before
+   /// this field carry no answer and are read as sorted, as they always were.
+   static bool fgCoordinateSorted;
+   static int32_t fgLastPlacedRefId;
+   static int32_t fgLastPlacedPos;
+
 public:
    RAMNTupleRecord();
    ~RAMNTupleRecord() = default;
@@ -215,6 +223,15 @@ public:
    {
       if (span > fgMaxRefSpan)
          fgMaxRefSpan = span;
+   }
+   static bool IsCoordinateSorted() { return fgCoordinateSorted; }
+   /// Feeds one placed record to the running order check.
+   static void NotePlacement(int32_t refid_, int32_t pos_)
+   {
+      if (refid_ < fgLastPlacedRefId || (refid_ == fgLastPlacedRefId && pos_ < fgLastPlacedPos))
+         fgCoordinateSorted = false;
+      fgLastPlacedRefId = refid_;
+      fgLastPlacedPos = pos_;
    }
    /// Reference bases covered by this record's CIGAR (0 when it has none).
    uint32_t GetRefSpan() const;

--- a/src/ramcore/BamtoNTuple.cxx
+++ b/src/ramcore/BamtoNTuple.cxx
@@ -248,6 +248,8 @@ void bamtoramntuple(const char *bamfile, const char *treefile, bool index, bool 
    while (sam_read1(bamIn, hdr, rec) >= 0) {
       FillRecord(recordPtr.get(), rec, hdr, quality_policy);
       RAMNTupleRecord::NoteRefSpan(recordPtr->GetRefSpan());
+      if (!(rec->core.flag & kUnmapped) && recordPtr->GetREFID() >= 0)
+         RAMNTupleRecord::NotePlacement(recordPtr->GetREFID(), recordPtr->GetPOS() - 1);
       writer->Fill(*entry);
 
       if (index && !(rec->core.flag & kUnmapped) && recordPtr->GetREFID() >= 0) {
@@ -275,7 +277,12 @@ void bamtoramntuple(const char *bamfile, const char *treefile, bool index, bool 
    bam_destroy1(rec);
    writer.reset();
 
-   if (index)
+   // An index is only usable on a sorted file; the file records which it is.
+   const bool sorted = RAMNTupleRecord::IsCoordinateSorted();
+   if (index && !sorted)
+      std::cerr << bamfile
+                << " is not in coordinate order, so no index was written; region queries will read it in full.\n";
+   if (index && sorted)
       RAMNTupleRecord::WriteIndex(*rootFile);
    RAMNTupleRecord::WriteAllRefs(*rootFile);
 
@@ -306,7 +313,7 @@ void bamtoramntuple(const char *bamfile, const char *treefile, bool index, bool 
              << "Number of entries: " << count << "\n";
    RAMNTupleRecord::GetRnameRefs()->Print();
    RAMNTupleRecord::GetRnextRefs()->Print();
-   if (index)
+   if (index && sorted)
       std::cout << "Index entries: " << RAMNTupleRecord::GetIndex()->Size() << "\n";
 
    stopwatch.Print();

--- a/src/ramcore/RAMNTupleView.cxx
+++ b/src/ramcore/RAMNTupleView.cxx
@@ -155,9 +155,12 @@ Long64_t ramntuplescan(ROOT::RNTupleReader &reader, const char *query, const std
    // would step over it. Backing off by the longest span in the file is exact.
    // A file that does not record the span (0) is scanned from the reference's
    // first entry instead.
+   // Seeking and stopping early both assume coordinate order. A file without
+   // it is read end to end with the same overlap test.
+   const bool sorted = RAMNTupleRecord::IsCoordinateSorted();
    auto index = RAMNTupleRecord::GetIndex();
    Long64_t start = 0;
-   if (index && index->Size() > 0) {
+   if (sorted && index && index->Size() > 0) {
       const Int_t maxSpan = static_cast<Int_t>(RAMNTupleRecord::GetMaxRefSpan());
       const Int_t seekPos = (maxSpan > 0 && rs > maxSpan) ? rs - maxSpan : 0;
       start = index->GetRow(refid, seekPos);
@@ -169,14 +172,18 @@ Long64_t ramntuplescan(ROOT::RNTupleReader &reader, const char *query, const std
 
    for (Long64_t i = start; i < total; i++) {
       const int curRef = refidView(i);
-      if (curRef < refid)
+      if (curRef != refid) {
+         if (sorted && curRef > refid)
+            break;
          continue;
-      if (curRef > refid)
-         break;
+      }
 
       const int pos = posView(i);
-      if (pos > re)
-         break;
+      if (pos > re) {
+         if (sorted)
+            break;
+         continue;
+      }
 
       if (pos < rs && pos + computeRefSpan(cigarView(i)) - 1 < rs)
          continue;

--- a/src/ramcore/SamToNTuple.cxx
+++ b/src/ramcore/SamToNTuple.cxx
@@ -5,21 +5,17 @@
 #include <ROOT/RNTupleModel.hxx>
 #include <ROOT/RNTupleWriter.hxx>
 #include <ROOT/RNTupleWriteOptions.hxx>
-#include <ROOT/RNTupleParallelWriter.hxx>
-#include <ROOT/RNTupleFillContext.hxx>
 #include <TStopwatch.h>
 #include <TList.h>
 #include <TNamed.h>
 #include <TFile.h>
-#include <TROOT.h>
 
-#include <algorithm>
 #include <cstdint>
 #include <cstdio>
+#include <map>
 #include <memory>
-#include <mutex>
+#include <stdexcept>
 #include <string>
-#include <thread>
 #include <vector>
 
 namespace {
@@ -177,19 +173,36 @@ void samtoramntuple(const char *datafile,
     stopwatch.Print();
 }
 
+namespace {
+
+// One output file, held open while the input streams past it.
+struct ChromosomeWriter {
+   std::unique_ptr<TFile> file{};
+   std::unique_ptr<ROOT::RNTupleWriter> writer{};
+   std::unique_ptr<ROOT::REntry> entry{};
+   std::shared_ptr<RAMNTupleRecord> record{};
+   RAMNTupleIndex index{};
+   int64_t rows = 0;
+   int64_t mapped = 0;
+   int32_t last_pos = -1;
+   int32_t last_indexed_pos = -kPositionInterval;
+   bool sorted = true;
+};
+
+} // namespace
+
 void samtoramntuple_split_by_chromosome(const char *datafile, const char *output_prefix, int compression_algorithm,
-                                        uint32_t quality_policy, int num_threads)
+                                        uint32_t quality_policy)
 {
-   ROOT::EnableThreadSafety();
    RAMNTupleRecord::InitializeRefs();
 
-   std::map<std::string, std::vector<ramcore::SamRecord>> chromosome_records;
-   std::vector<std::pair<std::string, std::string>> headers;
-
-   ramcore::SamParser parser;
+   std::map<std::string, ChromosomeWriter> writers;
+   TList headers;
+   headers.SetName("headers");
+   headers.SetOwner(true);
 
    auto header_callback = [&](const std::string &tag, const std::string &content) {
-      headers.push_back({tag, content});
+      headers.Add(std::make_unique<TNamed>(tag.c_str(), content.c_str()).release());
 
       if (tag == "@SQ") {
          size_t sn_pos = content.find("SN:");
@@ -203,129 +216,103 @@ void samtoramntuple_split_by_chromosome(const char *datafile, const char *output
       }
    };
 
-   auto record_callback = [&](const ramcore::SamRecord &sam_record, size_t record_num) {
-      if (sam_record.rname != "*") {
-         chromosome_records[sam_record.rname].push_back(sam_record);
-      }
-   };
+   auto open_writer = [&](const std::string &chr) -> ChromosomeWriter & {
+      auto it = writers.find(chr);
+      if (it != writers.end())
+         return it->second;
 
-   parser.ParseFile(datafile, header_callback, record_callback);
+      ChromosomeWriter &cw = writers[chr];
+      std::string filename{output_prefix};
+      filename += "_";
+      filename += chr;
+      filename += ".root";
+      cw.file.reset(TFile::Open(filename.c_str(), "RECREATE"));
+      if (!cw.file || !cw.file->IsOpen())
+         throw std::runtime_error("cannot create " + filename);
 
-   std::vector<std::string> chr_names;
-   for (const auto &[chr, records] : chromosome_records) {
-      chr_names.push_back(chr);
-   }
-
-   std::vector<std::thread> sort_threads;
-   for (const auto &chr : chr_names) {
-      sort_threads.emplace_back([&chromosome_records, chr]() {
-         auto &records = chromosome_records[chr];
-         std::sort(records.begin(), records.end(),
-                   [](const ramcore::SamRecord &a, const ramcore::SamRecord &b) { return a.pos < b.pos; });
-      });
-   }
-   for (auto &t : sort_threads) {
-      t.join();
-   }
-
-   std::mutex global_record_mutex;
-
-   auto write_chromosome_parallel = [&](const std::string &chr, std::mutex &record_mutex) {
-      const auto &records = chromosome_records[chr];
-
-      std::string filename = std::string(output_prefix) + "_" + chr + ".root";
-
-      auto model = RAMNTupleRecord::MakeModel();
       ROOT::RNTupleWriteOptions writeOptions;
-
       writeOptions.SetCompression(compression_algorithm);
-      writeOptions.SetApproxZippedClusterSize(200 * 1024 * 1024);
-      writeOptions.SetMaxUnzippedClusterSize(1024 * 1024 * 1024);
-      writeOptions.SetMaxUnzippedPageSize(1024 * 1024);
-      writeOptions.SetUseBufferedWrite(true);
+      writeOptions.SetMaxUnzippedPageSize(64000);
+      // Every chromosome's buffers are open at once, so keep the clusters small.
+      writeOptions.SetApproxZippedClusterSize(8 * 1024 * 1024);
 
-      auto parallel_writer = ROOT::RNTupleParallelWriter::Recreate(std::move(model), "RAM", filename, writeOptions);
-
-      const int contexts_per_file = std::min(4, num_threads);
-      const size_t records_per_context = (records.size() + contexts_per_file - 1) / contexts_per_file;
-
-      std::vector<std::thread> write_threads;
-
-      for (int ctx = 0; ctx < contexts_per_file && ctx * records_per_context < records.size(); ++ctx) {
-         write_threads.emplace_back([&, ctx]() {
-            auto fill_context = parallel_writer->CreateFillContext();
-            auto entry = fill_context->GetModel().CreateEntry();
-            auto recordPtr = entry->GetPtr<RAMNTupleRecord>("record").get();
-
-            size_t start = ctx * records_per_context;
-            size_t end = std::min(start + records_per_context, records.size());
-            uint32_t max_span = 0;
-
-            for (size_t i = start; i < end; ++i) {
-               const auto &sam_record = records[i];
-
-               recordPtr->SetBit(quality_policy);
-               recordPtr->SetQNAME(sam_record.qname);
-               recordPtr->SetFLAG(sam_record.flag);
-
-               {
-                  std::lock_guard<std::mutex> lock(record_mutex);
-                  recordPtr->SetREFID(sam_record.rname);
-                  recordPtr->SetREFNEXT(sam_record.rnext);
-               }
-
-               recordPtr->SetPOS(sam_record.pos);
-               recordPtr->SetMAPQ(sam_record.mapq);
-               recordPtr->SetCIGAR(sam_record.cigar);
-               max_span = std::max(max_span, recordPtr->GetRefSpan());
-               recordPtr->SetPNEXT(sam_record.pnext);
-               recordPtr->SetTLEN(sam_record.tlen);
-               recordPtr->SetSEQ(sam_record.seq);
-               recordPtr->SetQUAL(sam_record.qual);
-
-               recordPtr->ResetNOPT();
-               for (const auto &opt : sam_record.optional_fields) {
-                  recordPtr->SetOPT(opt);
-               }
-
-               fill_context->Fill(*entry);
-            }
-
-            std::lock_guard<std::mutex> lock(record_mutex);
-            RAMNTupleRecord::NoteRefSpan(max_span);
-         });
-      }
-
-      for (auto &t : write_threads) {
-         t.join();
-      }
-
-      parallel_writer.reset();
-
-      std::unique_ptr<TFile> file(TFile::Open(filename.c_str(), "UPDATE"));
-
-      TList h;
-      h.SetName("headers");
-      for (const auto &[tag, content] : headers) {
-         h.Add(new TNamed(tag.c_str(), content.c_str()));
-      }
-
-      RAMNTupleRecord::WriteAllRefs(*file);
-      h.Write("headers", TObject::kSingleKey);
-
-      file->Close();
+      cw.writer = ROOT::RNTupleWriter::Append(RAMNTupleRecord::MakeModel(), "RAM", *cw.file, writeOptions);
+      cw.entry = cw.writer->GetModel().CreateEntry();
+      cw.record = cw.entry->GetPtr<RAMNTupleRecord>("record");
+      return cw;
    };
 
-   size_t chr_idx = 0;
-   while (chr_idx < chr_names.size()) {
-      std::vector<std::thread> threads;
+   auto record_callback = [&](const ramcore::SamRecord &sam_record, size_t) {
+      // A record with no reference has no chromosome file to go to.
+      if (sam_record.rname == "*")
+         return;
 
-      for (int i = 0; i < num_threads && chr_idx < chr_names.size(); ++i, ++chr_idx) {
-         threads.emplace_back(write_chromosome_parallel, chr_names[chr_idx], std::ref(global_record_mutex));
-      }
+      ChromosomeWriter &cw = open_writer(sam_record.rname);
+      RAMNTupleRecord &rec = *cw.record;
 
-      for (auto &t : threads) {
-         t.join();
+      rec.SetBit(quality_policy);
+      rec.SetQNAME(sam_record.qname);
+      rec.SetFLAG(sam_record.flag);
+      rec.SetREFID(sam_record.rname);
+      rec.SetPOS(sam_record.pos);
+      rec.SetMAPQ(sam_record.mapq);
+      rec.SetCIGAR(sam_record.cigar);
+      rec.SetREFNEXT(sam_record.rnext);
+      rec.SetPNEXT(sam_record.pnext);
+      rec.SetTLEN(sam_record.tlen);
+      rec.SetSEQ(sam_record.seq);
+      rec.SetQUAL(sam_record.qual);
+
+      rec.ResetNOPT();
+      for (const auto &opt : sam_record.optional_fields)
+         rec.SetOPT(opt);
+
+      RAMNTupleRecord::NoteRefSpan(rec.GetRefSpan());
+      cw.writer->Fill(*cw.entry);
+      const int64_t row = cw.rows++;
+
+      if (sam_record.flag & kUnmapped)
+         return;
+
+      const int32_t pos = rec.GetPOS() - 1;
+      if (pos < cw.last_pos)
+         cw.sorted = false;
+      cw.last_pos = pos;
+
+      // Same sparse-index rule as the single-file writer, kept per file so the
+      // rows it records are the rows of this file.
+      const bool far_enough = (pos - cw.last_indexed_pos >= kPositionInterval);
+      const bool periodic = (cw.mapped % kMappedInterval == 0);
+      if ((far_enough || periodic) && pos != cw.last_indexed_pos) {
+         cw.index.AddItem(rec.GetREFID(), pos, row);
+         cw.last_indexed_pos = pos;
       }
+      cw.mapped++;
+   };
+
+   ramcore::SamParser parser;
+   if (!parser.ParseFile(datafile, header_callback, record_callback)) {
+      printf("Failed to parse SAM file %s\n", datafile);
+      return;
+   }
+
+   // The reference table and the longest span are only complete once the whole
+   // input has been read, so every file is finished here.
+   for (auto &[chr, cw] : writers) {
+      cw.writer.reset();
+
+      RAMNTupleRecord::SetCoordinateSorted(cw.sorted);
+      if (cw.sorted)
+         RAMNTupleRecord::WriteIndex(*cw.file, cw.index);
+      else
+         fprintf(stderr, "%s: %s is not in coordinate order, so no index was written.\n", datafile, chr.c_str());
+      RAMNTupleRecord::WriteAllRefs(*cw.file);
+
+      cw.file->cd();
+      headers.Write("headers", TObject::kSingleKey);
+      cw.file->Close();
+
+      printf("%s_%s.root: %lld records, %zu index entries\n", output_prefix, chr.c_str(),
+             static_cast<long long>(cw.rows), cw.sorted ? cw.index.Size() : 0);
    }
 }

--- a/src/ramcore/SamToNTuple.cxx
+++ b/src/ramcore/SamToNTuple.cxx
@@ -102,6 +102,8 @@ void samtoramntuple(const char *datafile,
        }
 
        RAMNTupleRecord::NoteRefSpan(recordPtr->GetRefSpan());
+       if (!(sam_record.flag & kUnmapped) && recordPtr->GetREFID() >= 0)
+          RAMNTupleRecord::NotePlacement(recordPtr->GetREFID(), recordPtr->GetPOS() - 1);
        writer->Fill(*defaultEntry);
 
        // Index building: create a sparse lookup table so region queries can jump
@@ -143,8 +145,14 @@ void samtoramntuple(const char *datafile,
 
     writer.reset();
 
-    if (index) {
-        RAMNTupleRecord::WriteIndex(*rootFile);
+    // An index is only usable on a sorted file; the file records which it is.
+    const bool sorted = RAMNTupleRecord::IsCoordinateSorted();
+    if (index && !sorted) {
+       fprintf(stderr, "%s is not in coordinate order, so no index was written; region queries will read it in full.\n",
+               datafile);
+    }
+    if (index && sorted) {
+       RAMNTupleRecord::WriteIndex(*rootFile);
     }
     RAMNTupleRecord::WriteAllRefs(*rootFile);
 
@@ -159,8 +167,8 @@ void samtoramntuple(const char *datafile,
     RAMNTupleRecord::GetRnameRefs()->Print();
     RAMNTupleRecord::GetRnextRefs()->Print();
 
-    if (index) {
-        printf("\nIndex entries: %zu\n", RAMNTupleRecord::GetIndex()->Size());
+    if (index && sorted) {
+       printf("\nIndex entries: %zu\n", RAMNTupleRecord::GetIndex()->Size());
     }
 
     printf("\nProcessed %zu SAM headers\n", parser.GetLinesProcessed() - parser.GetRecordsProcessed());

--- a/src/rntuple/RAMNTupleRecord.cxx
+++ b/src/rntuple/RAMNTupleRecord.cxx
@@ -328,7 +328,13 @@ void RAMNTupleRecord::ReadAllRefs(const std::string &filename)
 
 void RAMNTupleRecord::WriteIndex(TFile &file)
 {
-   if (!fgIndex || fgIndex->Size() == 0 || !file.IsOpen())
+   if (fgIndex)
+      WriteIndex(file, *fgIndex);
+}
+
+void RAMNTupleRecord::WriteIndex(TFile &file, const RAMNTupleIndex &index)
+{
+   if (index.Size() == 0 || !file.IsOpen())
       return;
    file.cd();
 
@@ -343,7 +349,7 @@ void RAMNTupleRecord::WriteIndex(TFile &file)
    auto indexEntry = indexWriter->GetModel().CreateEntry();
    auto indexPtr = indexEntry->GetPtr<std::vector<RAMNTupleIndex::IndexEntry>>("index_entries");
 
-   *indexPtr = fgIndex->GetEntries();
+   *indexPtr = index.GetEntries();
    indexWriter->Fill(*indexEntry);
 }
 

--- a/src/rntuple/RAMNTupleRecord.cxx
+++ b/src/rntuple/RAMNTupleRecord.cxx
@@ -215,8 +215,9 @@ void RAMNTupleRecord::InitializeRefs()
       fgRnextRefs = std::make_unique<RAMNTupleRefs>();
    if (!fgIndex)
       fgIndex = std::make_unique<RAMNTupleIndex>();
-   // Per-file, so a second conversion in the same process does not inherit the
-   // first file's span.
+   // Per-file, so a second file in the same process does not inherit the
+   // first one's index or span.
+   fgIndex->Clear();
    fgMaxRefSpan = 0;
 }
 

--- a/src/rntuple/RAMNTupleRecord.cxx
+++ b/src/rntuple/RAMNTupleRecord.cxx
@@ -19,6 +19,9 @@ std::unique_ptr<RAMNTupleRefs> RAMNTupleRecord::fgRnameRefs = nullptr;
 std::unique_ptr<RAMNTupleRefs> RAMNTupleRecord::fgRnextRefs = nullptr;
 std::unique_ptr<RAMNTupleIndex> RAMNTupleRecord::fgIndex = nullptr;
 uint32_t RAMNTupleRecord::fgMaxRefSpan = 0;
+bool RAMNTupleRecord::fgCoordinateSorted = true;
+int32_t RAMNTupleRecord::fgLastPlacedRefId = -1;
+int32_t RAMNTupleRecord::fgLastPlacedPos = -1;
 
 static constexpr std::array<char, 16> kCodeToSeq{'=', 'A', 'C', 'M', 'G', 'R', 'S', 'V',
                                                  'T', 'W', 'Y', 'H', 'K', 'D', 'B', 'N'};
@@ -219,6 +222,9 @@ void RAMNTupleRecord::InitializeRefs()
    // first one's index or span.
    fgIndex->Clear();
    fgMaxRefSpan = 0;
+   fgCoordinateSorted = true;
+   fgLastPlacedRefId = -1;
+   fgLastPlacedPos = -1;
 }
 
 std::unique_ptr<RNTupleReader> RAMNTupleRecord::OpenRAMFile(const std::string &filename, const std::string &ntupleName)
@@ -249,6 +255,7 @@ void RAMNTupleRecord::WriteAllRefs(TFile &file)
    auto rnameField = metaModel->MakeField<std::vector<std::string>>("rname_refs");
    auto rnextField = metaModel->MakeField<std::vector<std::string>>("rnext_refs");
    auto spanField = metaModel->MakeField<uint32_t>("max_ref_span");
+   auto sortedField = metaModel->MakeField<bool>("coordinate_sorted");
 
    RNTupleWriteOptions writeOptions;
    writeOptions.SetCompression(505);
@@ -259,10 +266,12 @@ void RAMNTupleRecord::WriteAllRefs(TFile &file)
    auto rnextPtr = metaEntry->GetPtr<std::vector<std::string>>("rnext_refs");
 
    auto spanPtr = metaEntry->GetPtr<uint32_t>("max_ref_span");
+   auto sortedPtr = metaEntry->GetPtr<bool>("coordinate_sorted");
 
    *rnamePtr = fgRnameRefs->GetRefs();
    *rnextPtr = fgRnextRefs->GetRefs();
    *spanPtr = fgMaxRefSpan;
+   *sortedPtr = fgCoordinateSorted;
    metaWriter->Fill(*metaEntry);
 }
 
@@ -289,6 +298,14 @@ void RAMNTupleRecord::ReadAllRefs(const std::string &filename)
       try {
          auto span_view = reader->GetView<uint32_t>("max_ref_span");
          fgMaxRefSpan = span_view(0);
+      } catch (...) {
+         // Field doesn't exist
+      }
+
+      fgCoordinateSorted = true;
+      try {
+         auto sorted_view = reader->GetView<bool>("coordinate_sorted");
+         fgCoordinateSorted = sorted_view(0);
       } catch (...) {
          // Field doesn't exist
       }

--- a/test/chromosome_split_test.cxx
+++ b/test/chromosome_split_test.cxx
@@ -1,4 +1,5 @@
 #include <gtest/gtest.h>
+#include "ramcore/RAMNTupleView.h"
 #include "ramcore/SamToNTuple.h"
 #include "rntuple/RAMNTupleRecord.h"
 #include "generate_sam_benchmark.h"
@@ -36,7 +37,7 @@ TEST_F(ChromosomeSplitTest, NoDataLoss)
    auto regularReader = ROOT::RNTupleReader::Open("RAM", "test_regular.root");
    Long64_t totalEntries = regularReader->GetNEntries();
 
-   samtoramntuple_split_by_chromosome("test.sam", "test_split", 505, 1, 4);
+   samtoramntuple_split_by_chromosome("test.sam", "test_split", 505, 1);
 
    Long64_t splitEntriesSum = 0;
    for (const auto &entry : std::filesystem::directory_iterator(".")) {
@@ -54,7 +55,7 @@ TEST_F(ChromosomeSplitTest, NoDataLoss)
 
 TEST_F(ChromosomeSplitTest, CorrectChromosomeAssignment)
 {
-   samtoramntuple_split_by_chromosome("test.sam", "test_split", 505, 1, 4);
+   samtoramntuple_split_by_chromosome("test.sam", "test_split", 505, 1);
 
    for (const auto &entry : std::filesystem::directory_iterator(".")) {
       std::string filename = entry.path().filename().string();
@@ -79,7 +80,7 @@ TEST_F(ChromosomeSplitTest, CorrectChromosomeAssignment)
 
 TEST_F(ChromosomeSplitTest, MetadataPresent)
 {
-   samtoramntuple_split_by_chromosome("test.sam", "test_split", 505, 1, 4);
+   samtoramntuple_split_by_chromosome("test.sam", "test_split", 505, 1);
 
    int filesChecked = 0;
    for (const auto &entry : std::filesystem::directory_iterator(".")) {
@@ -97,4 +98,19 @@ TEST_F(ChromosomeSplitTest, MetadataPresent)
    }
 
    EXPECT_GT(filesChecked, 0);
+}
+
+TEST_F(ChromosomeSplitTest, RegionCountsMatchTheUnsplitFile)
+{
+   samtoramntuple("test.sam", "test_regular.root", false, true, true, 505, 1);
+   samtoramntuple_split_by_chromosome("test.sam", "test_split", 505, 1);
+
+   for (const auto &entry : std::filesystem::directory_iterator(".")) {
+      std::string filename = entry.path().filename().string();
+      if (filename.find("test_split_") != 0 || filename.find(".root") == std::string::npos)
+         continue;
+      std::string chr = filename.substr(11, filename.size() - 11 - 5);
+      EXPECT_EQ(ramntupleview(filename.c_str(), chr.c_str()), ramntupleview("test_regular.root", chr.c_str()))
+         << filename;
+   }
 }

--- a/test/ramcoretests.cxx
+++ b/test/ramcoretests.cxx
@@ -282,6 +282,65 @@ TEST_F(ramcoreTest, ScanVisitsEveryOverlappingRowInOrder)
    std::remove(rntupleFile);
 }
 
+// A region query seeks to an index entry and stops at the first record past
+// the region. Both assume coordinate order, so a file without it is read end
+// to end instead, and gets no index.
+TEST_F(ramcoreTest, UnsortedFileIsReadInFullAndNotIndexed)
+{
+   const char *customSam = "test_unsorted.sam";
+   const char *rntupleFile = "test_unsorted.root";
+
+   {
+      std::ofstream sam(customSam);
+      sam << "@HD\tVN:1.6\tSO:unsorted\n";
+      sam << "@SQ\tSN:chr1\tLN:100000\n";
+      // Only a and d overlap chr1:1000-1100. A query that stopped at the first
+      // record past the region would report a and never reach d.
+      sam << "a\t0\tchr1\t1000\t60\t50M\t*\t0\t0\t" << std::string(50, 'A') << "\t*\n";
+      sam << "b\t0\tchr1\t90000\t60\t50M\t*\t0\t0\t" << std::string(50, 'C') << "\t*\n";
+      sam << "c\t0\tchr1\t50000\t60\t50M\t*\t0\t0\t" << std::string(50, 'G') << "\t*\n";
+      sam << "d\t0\tchr1\t1050\t60\t50M\t*\t0\t0\t" << std::string(50, 'T') << "\t*\n";
+   }
+
+   testing::internal::CaptureStderr();
+   samtoramntuple(customSam, rntupleFile, /*index=*/true, false, false, 505, 0);
+   EXPECT_NE(testing::internal::GetCapturedStderr().find("not in coordinate order"), std::string::npos);
+
+   EXPECT_EQ(ramntupleview(rntupleFile, "chr1:1000-1100", opts), 2);
+   EXPECT_EQ(ramntupleview(rntupleFile, "chr1:50000-50010", opts), 1);
+   EXPECT_EQ(ramntupleview(rntupleFile, "chr1:2000-3000", opts), 0);
+   EXPECT_FALSE(RAMNTupleRecord::IsCoordinateSorted());
+   EXPECT_EQ(RAMNTupleRecord::GetIndex()->Size(), 0U);
+
+   std::remove(customSam);
+   std::remove(rntupleFile);
+}
+
+TEST_F(ramcoreTest, SortedFileIsIndexedAndMarkedSorted)
+{
+   const char *customSam = "test_sorted.sam";
+   const char *rntupleFile = "test_sorted.root";
+
+   {
+      std::ofstream sam(customSam);
+      sam << "@HD\tVN:1.6\tSO:coordinate\n";
+      sam << "@SQ\tSN:chr1\tLN:100000\n";
+      for (int i = 0; i < 300; ++i)
+         sam << "r" << i << "\t0\tchr1\t" << (1000 + i * 100) << "\t60\t50M\t*\t0\t0\t" << std::string(50, 'A')
+             << "\t*\n";
+   }
+
+   samtoramntuple(customSam, rntupleFile, /*index=*/true, false, false, 505, 0);
+
+   auto reader = RAMNTupleRecord::OpenRAMFile(rntupleFile);
+   ASSERT_NE(reader, nullptr);
+   EXPECT_TRUE(RAMNTupleRecord::IsCoordinateSorted());
+   EXPECT_GT(RAMNTupleRecord::GetIndex()->Size(), 0U);
+
+   std::remove(customSam);
+   std::remove(rntupleFile);
+}
+
 TEST_F(ramcoreTest, IndexGetRowsInRange)
 {
    RAMNTupleRecord::InitializeRefs();
@@ -307,10 +366,19 @@ TEST_F(ramcoreTest, IndexGetRowsInRange)
    ASSERT_EQ(otherChrom.size(), 1U);
    EXPECT_EQ(otherChrom[0], 3);
 
-   // test with generated entries
+   // test with generated entries; the input has to be sorted to get an index
+   const char *mockSam = "test_mock_index.sam";
    const char *mockFile = "test_mock_index.root";
-   samtoramntuple(/*datafile=*/"samexample.sam", mockFile, /*index=*/true, /*split=*/true, /*cache=*/true,
-                  /*compression_algorithm=*/505, /*quality_policy=*/0);
+   {
+      std::ofstream sam(mockSam);
+      sam << "@HD\tVN:1.6\tSO:coordinate\n";
+      sam << "@SQ\tSN:chr1\tLN:1000000\n";
+      for (int i = 0; i < 100; ++i)
+         sam << "r" << i << "\t0\tchr1\t" << (1 + i * 1000) << "\t60\t36M\t*\t0\t0\t" << std::string(36, 'A')
+             << "\t*\n";
+   }
+   samtoramntuple(mockSam, mockFile, /*index=*/true, /*split=*/true, /*cache=*/true, /*compression_algorithm=*/505,
+                  /*quality_policy=*/0);
 
    auto reader = RAMNTupleRecord::OpenRAMFile(mockFile);
    ASSERT_NE(reader, nullptr);
@@ -322,12 +390,13 @@ TEST_F(ramcoreTest, IndexGetRowsInRange)
    auto wideRows = index->GetRowsInRange(/*refid=*/chr1_refid, /*start=*/0, /*end=*/1000000000);
    for (int64_t row : wideRows) {
       EXPECT_GE(row, 0);
-      EXPECT_LT(row, 100); // record length of samexample.sam is 100 in SetUp()
+      EXPECT_LT(row, 100);
    }
 
    auto invalidRows = index->GetRowsInRange(/*refid=*/-1, /*start=*/0, /*end=*/1000000000);
    EXPECT_TRUE(invalidRows.empty());
 
+   std::remove(mockSam);
    std::remove(mockFile);
 }
 

--- a/tools/samtoramntuple.cxx
+++ b/tools/samtoramntuple.cxx
@@ -86,7 +86,7 @@ int main(int argc, char* argv[]) {
 
     try {
        if (do_split) {
-          samtoramntuple_split_by_chromosome(input, output, compression, quality_mode, 4);
+          samtoramntuple_split_by_chromosome(input, output, compression, quality_mode);
        } else {
           std::string ramfile = std::string(output);
           if (ramfile.find(".root") == std::string::npos && ramfile.find(".ram") == std::string::npos) {


### PR DESCRIPTION
Start every file with an empty index. InitializeRefs runs before each conversion and each open but left the previous file's index in place, so a file with no INDEX ntuple answered region queries with the rows of whatever file came before it in the same process.

Record whether a RAM file is sorted. A region query seeks to an index entry and stops at the first record past the region; both steps assume coordinate order. On an unsorted file (the repository's own generator emits one) the query walked past reads that belong in the answer and reported fewer records than samtools. Conversion now tracks the order it sees and stores it as coordinate_sorted. A sorted file keeps the seek and the early exit; an unsorted one is read end to end with the same overlap test. An unsorted file gets no index, and the conversion says so. Files written before this field are read as sorted, so existing files behave as before.

Stream the chromosome split. samtoramntuple_split_by_chromosome collected every record into a map of vectors and wrote nothing until the input was exhausted, so peak memory was the size of the input and a 72 GB SAM could not be split on an 11 GB machine. It sorted each chromosome with std::sort, which reorders records that share a position, and wrote no index. Records now go straight to their chromosome's open writer as they are parsed; each file keeps arrival order, records whether that order is coordinate order, and gets its own index when it is. The thread count existed only for the buffered writes and is gone, along with the parallel writer.
